### PR TITLE
Add phase 2 expansion planning documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ README.md
 3. 使用 **Preview** 按鈕於編輯器模式播放視覺模擬。
 4. 透過 **Export JSON** / **Import JSON** 保存或載入純文字 Recipe 設定。
 
+## 🧭 Phase 2 擴充藍圖
+- 以日本花火風格為靈感，將「紙皮層數、星粒排列、導火延遲、特效粉末」抽象為純數值參數。
+- 第二階段分為三個功能分支，詳細請見 `docs/phase2-expansion-plan.md`：
+  - **Workshop & Material System**：建立材料資料庫、工作坊 UI 與 JSON 匯入／匯出。
+  - **Assembly & Crafting Flow**：提供積木式製作流程、視覺化製作痕跡、TimingTrack 強化。
+  - **Economy & Growth**：導入材料價格、合約需求、品質評分與進程解鎖。
+- Demo 場景將展示「購買材料 → 拼裝配方 → 測試 → 賣出升級」的循環，所有內容皆為視覺模擬用途。
+
 ## 📦 JSON 匯出／匯入
 - 匯出：於 Inspector 點擊 **Export JSON**，指定路徑後即可產生純文字 JSON。
 - 匯入：於 Inspector 點擊 **Import JSON**，選擇先前匯出的檔案即可覆寫 ScriptableObject 參數。

--- a/docs/phase2-expansion-plan.md
+++ b/docs/phase2-expansion-plan.md
@@ -1,0 +1,93 @@
+# PYRO_LAB Phase 2 Expansion Plan
+
+> **Scope Reminder**: All mechanics described below are purely abstract gameplay and visualization systems. No part of this plan references or implies real-world pyrotechnic manufacturing.
+
+## Vision Overview
+- Embrace Japanese-inspired hanabi aesthetics (e.g., peony, chrysanthemum, willow, thousand-burst, double-bloom patterns).
+- Highlight the craft fantasy through abstract parameters such as outer shell layers, star arrangement, fuse timing, and effect modifiers.
+- Support a light-weight economy loop where players acquire materials, assemble recipes, test fireworks in the demo scene, and sell results to progress.
+
+## Milestone Breakdown
+The second-phase roadmap is split into three feature branches. Each branch should be independently reviewable and merged in order.
+
+### A. Workshop & Material System (`feature/workshop-materials`)
+**PR Title**: `Add abstract workshop & material system`
+
+**Objectives**
+1. **Material Database**
+   - Implement a ScriptableObject or JSON-driven registry of abstract materials.
+   - Each material only exposes gameplay parameters:
+     - `outerShellLayer` (int 1–5): thicker shells produce rounder, longer-lasting bursts.
+     - `colorSet` (gradient/palette reference): used when composing `FireworkLayer` gradients.
+     - `twinkleFactor` (0–1): drives `TwinkleModifier` intensity.
+     - `trailFactor` (0–1): scales `TrailModifier` length.
+   - Prepare editor tooling to add/remove materials and assign categories (paper, color powder, special effect powder).
+2. **Workshop UI Skeleton**
+   - Add a demo scene canvas with controls to choose shell layers, color palettes, and effect powders.
+   - Selected options generate a `FireworkRecipe` preview asset in memory and push changes to the existing spawner.
+3. **Serialization Hooks**
+   - Extend the JSON import/export utilities to capture workshop selections alongside recipes for easy sharing.
+
+**Deliverables**
+- Data definitions for material entries.
+- Basic workshop interface in the demo scene.
+- Updated JSON schema and example presets.
+
+### B. Assembly & Crafting Flow (`feature/assembly-flow`)
+**PR Title**: `Add crafting assembly flow (visual recipe builder)`
+
+**Objectives**
+1. **Step-based Builder UI**
+   - Introduce a staged interface guiding players through: outer shell selection → star arrangement → modifiers.
+   - Provide visual thumbnails or text descriptors for arrangements such as sphere shell, ring, heart, willow, double bloom.
+   - Link selections directly to `FireworkLayer` and `VisualModifier` instances.
+2. **Live Craft Visualization**
+   - Display crafting feedback in the demo scene (e.g., thicker shells yield smoother bursts, fewer layers create scattered results).
+   - Optionally overlay debug widgets that describe the assembled layers and modifiers.
+3. **TimingTrack Enhancements**
+   - Allow scheduling of double-burst events or color shifts using interactive timeline controls.
+
+**Deliverables**
+- Scriptable definitions (e.g., `FireworkLayerTemplate`) to map assembly choices into recipes.
+- UI prefabs for the stepper workflow.
+- Integration with the existing timing/preview system.
+
+### C. Economy & Growth (`feature/economy-system`)
+**PR Title**: `Add abstract economy & progression system`
+
+**Objectives**
+1. **Material Pricing & Inventory**
+   - Assign in-game currency costs to each material category.
+   - Track player balance, owned materials, and consumption during crafting.
+2. **Quality Scoring & Sales**
+   - After testing a firework, compute a quality score using visual metrics (e.g., symmetry, duration, modifier usage).
+   - Convert quality into sale price and update player balance.
+3. **Contract Missions**
+   - Author lightweight contracts (ScriptableObject or JSON) describing requested features (e.g., “willow + double bloom + gold hue”).
+   - Validate crafted recipes against contract requirements to unlock payouts.
+4. **Progression Curve**
+   - Gate advanced materials behind milestones (e.g., total revenue, contract completions).
+   - Communicate progression tiers: early (basic spheres), mid (double bloom, trails, heart shapes), late (large-scale shells).
+
+**Deliverables**
+- Currency & inventory scripts.
+- Contract definition assets and validation logic.
+- Progression configuration and UI feedback for unlocks.
+
+## Demo Scene Expectations
+- Provide an accessible UI flow that demonstrates buying materials, assembling components, testing fireworks, and selling the result.
+- Ensure all descriptions, tooltips, and labels reiterate the purely visual, game-development intent.
+
+## Documentation Checklist
+- Update `README.md` and relevant in-project tooltips to emphasize the abstract nature of the systems.
+- Include usage notes for new editors/UI elements.
+- Supply JSON or ScriptableObject samples for materials, recipes, and contracts.
+
+## Testing Guidance
+- Manual playtest in the demo scene covering: material selection, recipe assembly, double-burst timing, economy transactions, and contract fulfillment.
+- Validate JSON import/export across all new data models.
+
+## Safety & Compliance
+- Maintain the project-wide disclaimer: **visual simulation only—no real-world fabrication guidance**.
+- Avoid any real chemical names or hazardous procedures in assets, code, or documentation.
+


### PR DESCRIPTION
## Summary
- document the phase two roadmap covering workshop, assembly, and economy systems
- outline feature branch goals, deliverables, and safety constraints for upcoming work
- update the README with a roadmap section pointing to the detailed plan

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e02a35f3d88328ba412093edd1b4b6