### PR TITLE
Add Recipe Editor GUI, JSON import/export, and in-project recipe library (visual-only)

### DIFF
--- a/Assets/Recipes.meta
+++ b/Assets/Recipes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c2343d6611f24685b245ac08fd36f259
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/RecipesJSON.meta
+++ b/Assets/RecipesJSON.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 36dfd6d80e9c40409b6aaab588a73d9b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Core/Data/RecipeCatalog.asset
+++ b/Assets/_Core/Data/RecipeCatalog.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 946925e6497444c7b7a032c78feebaef, type: 3}
+  m_Name: RecipeCatalog
+  m_EditorClassIdentifier:
+  recipes:
+  - {fileID: 11400000, guid: 5bded450dfd5417b82c0b1f235d6ce12, type: 2}
+  - {fileID: 11400000, guid: 6d0d9385d30d4fdf9a995611c3bb6447, type: 2}
+  - {fileID: 11400000, guid: 8a8210fb3f4e48f599a0e9ed7e3fb510, type: 2}

--- a/Assets/_Core/Data/RecipeCatalog.asset.meta
+++ b/Assets/_Core/Data/RecipeCatalog.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6e1abb368f704aa7924e8dc6db4ac12f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Core/Data/RecipeCatalog.cs
+++ b/Assets/_Core/Data/RecipeCatalog.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace PyroLab.Fireworks
+{
+    [CreateAssetMenu(menuName = "PYRO/Recipe Catalog", fileName = "RecipeCatalog")]
+    public class RecipeCatalog : ScriptableObject
+    {
+        [SerializeField] private List<FireworkRecipe> recipes = new();
+
+        public IReadOnlyList<FireworkRecipe> Recipes => recipes;
+
+        public FireworkRecipe GetRecipeByName(string recipeName)
+        {
+            if (string.IsNullOrWhiteSpace(recipeName))
+            {
+                return null;
+            }
+
+            return recipes.FirstOrDefault(r => r != null && r.name == recipeName);
+        }
+
+        public bool TryGetRecipe(int index, out FireworkRecipe recipe)
+        {
+            if (index < 0 || index >= recipes.Count)
+            {
+                recipe = null;
+                return false;
+            }
+
+            recipe = recipes[index];
+            return recipe != null;
+        }
+
+#if UNITY_EDITOR
+        public void AddRecipe(FireworkRecipe recipe)
+        {
+            if (recipe == null || recipes.Contains(recipe))
+            {
+                return;
+            }
+
+            recipes.Add(recipe);
+            UnityEditor.EditorUtility.SetDirty(this);
+        }
+#endif
+    }
+}

--- a/Assets/_Core/Data/RecipeCatalog.cs.meta
+++ b/Assets/_Core/Data/RecipeCatalog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 946925e6497444c7b7a032c78feebaef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Core/Data/Resources.meta
+++ b/Assets/_Core/Data/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d4aad0fa058548ed98ffa5081eb77ff9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Core/Data/Resources/RecipeCatalog.asset
+++ b/Assets/_Core/Data/Resources/RecipeCatalog.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 946925e6497444c7b7a032c78feebaef, type: 3}
+  m_Name: RecipeCatalog
+  m_EditorClassIdentifier:
+  recipes:
+  - {fileID: 11400000, guid: 5bded450dfd5417b82c0b1f235d6ce12, type: 2}
+  - {fileID: 11400000, guid: 6d0d9385d30d4fdf9a995611c3bb6447, type: 2}
+  - {fileID: 11400000, guid: 8a8210fb3f4e48f599a0e9ed7e3fb510, type: 2}

--- a/Assets/_Core/Data/Resources/RecipeCatalog.asset.meta
+++ b/Assets/_Core/Data/Resources/RecipeCatalog.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5ab61faae52347aa97b4e2afbc52b741
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Core/Editor/FireworkRecipeEditor.cs
+++ b/Assets/_Core/Editor/FireworkRecipeEditor.cs
@@ -19,8 +19,6 @@ namespace PyroLab.Fireworks.Editor
         private ParticleSystem previewBurst;
         private Light previewLight;
 
-        private const string DefaultExportFileName = "FireworkRecipe.json";
-
         private void OnEnable()
         {
             modifierTypes = GetModifierTypes();
@@ -392,24 +390,26 @@ namespace PyroLab.Fireworks.Editor
 
         private void ExportJson(FireworkRecipe recipe)
         {
-            string path = EditorUtility.SaveFilePanel("Export Firework Recipe", Application.dataPath, DefaultExportFileName, "json");
-            if (string.IsNullOrEmpty(path))
+            try
             {
-                return;
+                RecipeJsonUtility.ExportWithDialog(recipe);
             }
-
-            JsonPresetExporter.Export(recipe, path);
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+            }
         }
 
         private void ImportJson(FireworkRecipe recipe)
         {
-            string path = EditorUtility.OpenFilePanel("Import Firework Recipe", Application.dataPath, "json");
-            if (string.IsNullOrEmpty(path))
+            try
             {
-                return;
+                RecipeJsonUtility.OverwriteFromJsonWithDialog(recipe);
             }
-
-            JsonPresetExporter.Import(recipe, path);
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+            }
         }
 
         private void EnsurePreviewSystems()

--- a/Assets/_Core/Editor/JsonPresetExporter.cs
+++ b/Assets/_Core/Editor/JsonPresetExporter.cs
@@ -14,10 +14,7 @@ namespace PyroLab.Fireworks.Editor
                 return;
             }
 
-            string json = recipe.ExportToJson();
-            File.WriteAllText(path, json);
-            Debug.Log($"Firework preset exported to {path}");
-            AssetDatabase.Refresh();
+            RecipeJsonUtility.ExportToPath(recipe, path);
         }
 
         public static void Import(FireworkRecipe recipe, string path)
@@ -34,10 +31,7 @@ namespace PyroLab.Fireworks.Editor
                 return;
             }
 
-            string json = File.ReadAllText(path);
-            recipe.ImportFromJson(json);
-            EditorUtility.SetDirty(recipe);
-            Debug.Log($"Firework preset imported from {path}");
+            RecipeJsonUtility.OverwriteFromJson(recipe, path);
         }
     }
 }

--- a/Assets/_Core/Editor/RecipeEditorWindow.cs
+++ b/Assets/_Core/Editor/RecipeEditorWindow.cs
@@ -1,0 +1,411 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditorInternal;
+using UnityEngine;
+
+namespace PyroLab.Fireworks.Editor
+{
+    public class RecipeEditorWindow : EditorWindow
+    {
+        private FireworkRecipe currentRecipe;
+        private SerializedObject serializedRecipe;
+        private ReorderableList layerList;
+        private Vector2 scroll;
+
+        private FireworkLauncher previewLauncher;
+        private ParticleSystem previewLift;
+        private ParticleSystem previewBurst;
+        private Light previewLight;
+
+        private readonly Dictionary<int, bool> layerFoldouts = new();
+
+        [MenuItem("PYRO/Recipe Editor", priority = 0)]
+        public static void Open()
+        {
+            var window = GetWindow<RecipeEditorWindow>("Recipe Editor");
+            window.minSize = new Vector2(420f, 320f);
+            window.Show();
+        }
+
+        private void OnEnable()
+        {
+            TryLoadSelection();
+        }
+
+        private void OnDisable()
+        {
+            if (previewLauncher != null)
+            {
+                DestroyImmediate(previewLauncher.gameObject);
+            }
+        }
+
+        private void OnSelectionChange()
+        {
+            TryLoadSelection();
+            Repaint();
+        }
+
+        private void TryLoadSelection()
+        {
+            if (Selection.activeObject is FireworkRecipe recipe)
+            {
+                LoadRecipe(recipe);
+            }
+        }
+
+        private void LoadRecipe(FireworkRecipe recipe)
+        {
+            if (recipe == currentRecipe)
+            {
+                return;
+            }
+
+            currentRecipe = recipe;
+            serializedRecipe = recipe != null ? new SerializedObject(recipe) : null;
+            ConfigureLayerList();
+        }
+
+        private void ConfigureLayerList()
+        {
+            if (serializedRecipe == null)
+            {
+                layerList = null;
+                return;
+            }
+
+            layerFoldouts.Clear();
+            var layersProperty = serializedRecipe.FindProperty("layers");
+            layerList = new ReorderableList(serializedRecipe, layersProperty, true, true, false, false);
+            layerList.drawHeaderCallback = rect =>
+            {
+                EditorGUI.LabelField(rect, "Layers");
+            };
+
+            layerList.drawElementCallback = (rect, index, active, focused) =>
+            {
+                var element = layersProperty.GetArrayElementAtIndex(index);
+                rect.height = EditorGUI.GetPropertyHeight(element, true);
+                rect.y += 2f;
+                rect.x += 4f;
+                rect.width -= 8f;
+                bool expanded = element.isExpanded;
+                if (!layerFoldouts.TryGetValue(index, out expanded))
+                {
+                    expanded = element.isExpanded;
+                }
+
+                element.isExpanded = expanded;
+                EditorGUI.PropertyField(rect, element, new GUIContent($"Layer {index + 1}"), true);
+                layerFoldouts[index] = element.isExpanded;
+            };
+
+            layerList.elementHeightCallback = index =>
+            {
+                var element = layersProperty.GetArrayElementAtIndex(index);
+                return EditorGUI.GetPropertyHeight(element, true) + 6f;
+            };
+
+            layerList.onReorderCallback = list =>
+            {
+                if (currentRecipe == null)
+                {
+                    return;
+                }
+
+                Undo.RecordObject(currentRecipe, "Reorder Layers");
+                serializedRecipe.ApplyModifiedProperties();
+                EditorUtility.SetDirty(currentRecipe);
+            };
+        }
+
+        private void OnGUI()
+        {
+            DrawToolbar();
+
+            if (currentRecipe == null)
+            {
+                EditorGUILayout.HelpBox("Select or create a FireworkRecipe asset to begin.", MessageType.Info);
+                return;
+            }
+
+            if (serializedRecipe == null)
+            {
+                return;
+            }
+
+            serializedRecipe.Update();
+
+            scroll = EditorGUILayout.BeginScrollView(scroll);
+            EditorGUILayout.PropertyField(serializedRecipe.FindProperty("size"));
+            EditorGUILayout.PropertyField(serializedRecipe.FindProperty("desiredBurstHeight"));
+            EditorGUILayout.PropertyField(serializedRecipe.FindProperty("fuseTime"));
+            EditorGUILayout.PropertyField(serializedRecipe.FindProperty("sizeOverLifetime"));
+            EditorGUILayout.PropertyField(serializedRecipe.FindProperty("colorOverLifetime"));
+            EditorGUILayout.PropertyField(serializedRecipe.FindProperty("hdrIntensity"));
+
+            EditorGUILayout.Space(8f);
+            if (layerList != null)
+            {
+                layerList.DoLayoutList();
+            }
+
+            EditorGUILayout.BeginHorizontal();
+            if (GUILayout.Button("Add Layer"))
+            {
+                AddLayer();
+            }
+
+            EditorGUI.BeginDisabledGroup(layerList == null || layerList.index < 0 || layerList.index >= currentRecipe.layers.Count);
+            if (GUILayout.Button("Duplicate Layer"))
+            {
+                DuplicateLayer(layerList.index);
+            }
+
+            if (GUILayout.Button("Delete Layer"))
+            {
+                RemoveLayer(layerList.index);
+            }
+            EditorGUI.EndDisabledGroup();
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.Space(8f);
+            EditorGUILayout.PropertyField(serializedRecipe.FindProperty("timing"), true);
+            EditorGUILayout.EndScrollView();
+
+            if (serializedRecipe.ApplyModifiedProperties())
+            {
+                EditorUtility.SetDirty(currentRecipe);
+            }
+        }
+
+        private void DrawToolbar()
+        {
+            using (new EditorGUILayout.HorizontalScope(EditorStyles.toolbar))
+            {
+                var selected = (FireworkRecipe)EditorGUILayout.ObjectField(currentRecipe, typeof(FireworkRecipe), false, GUILayout.MinWidth(160f));
+                if (selected != currentRecipe)
+                {
+                    LoadRecipe(selected);
+                }
+
+                if (GUILayout.Button("Select Asset", EditorStyles.toolbarButton, GUILayout.Width(90f)))
+                {
+                    if (currentRecipe != null)
+                    {
+                        Selection.activeObject = currentRecipe;
+                    }
+                }
+
+                if (GUILayout.Button("Create", EditorStyles.toolbarButton, GUILayout.Width(70f)))
+                {
+                    CreateNewRecipeAsset();
+                }
+
+                GUILayout.FlexibleSpace();
+
+                EditorGUI.BeginDisabledGroup(currentRecipe == null);
+                if (GUILayout.Button("Preview", EditorStyles.toolbarButton, GUILayout.Width(70f)))
+                {
+                    PlayPreview();
+                }
+
+                if (GUILayout.Button("Export JSON", EditorStyles.toolbarButton, GUILayout.Width(90f)))
+                {
+                    try
+                    {
+                        RecipeJsonUtility.ExportWithDialog(currentRecipe);
+                    }
+                    catch (System.Exception ex)
+                    {
+                        Debug.LogException(ex);
+                    }
+                }
+
+                if (GUILayout.Button("Import JSON", EditorStyles.toolbarButton, GUILayout.Width(90f)))
+                {
+                    try
+                    {
+                        RecipeJsonUtility.OverwriteFromJsonWithDialog(currentRecipe);
+                        serializedRecipe.Update();
+                    }
+                    catch (System.Exception ex)
+                    {
+                        Debug.LogException(ex);
+                    }
+                }
+
+                EditorGUI.EndDisabledGroup();
+
+                if (GUILayout.Button("Import as New", EditorStyles.toolbarButton, GUILayout.Width(110f)))
+                {
+                    try
+                    {
+                        var imported = RecipeJsonUtility.ImportAsNewAssetWithDialog();
+                        if (imported != null)
+                        {
+                            LoadRecipe(imported);
+                        }
+                    }
+                    catch (System.Exception ex)
+                    {
+                        Debug.LogException(ex);
+                    }
+                }
+            }
+        }
+
+        private void CreateNewRecipeAsset()
+        {
+            RecipeJsonUtility.EnsureAssetFolder();
+            string path = EditorUtility.SaveFilePanelInProject("Create Firework Recipe", "NewFireworkRecipe", "asset", "Select a save location for the new recipe.", RecipeJsonUtility.AssetFolderRelativePath);
+            if (string.IsNullOrEmpty(path))
+            {
+                return;
+            }
+
+            var recipe = ScriptableObject.CreateInstance<FireworkRecipe>();
+            AssetDatabase.CreateAsset(recipe, path);
+            EditorUtility.SetDirty(recipe);
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+            Selection.activeObject = recipe;
+            LoadRecipe(recipe);
+        }
+
+        private void AddLayer()
+        {
+            if (currentRecipe == null)
+            {
+                return;
+            }
+
+            Undo.RecordObject(currentRecipe, "Add Layer");
+            currentRecipe.layers ??= new List<FireworkLayer>();
+            currentRecipe.layers.Add(new FireworkLayer());
+            serializedRecipe.Update();
+            if (layerList != null)
+            {
+                layerList.index = currentRecipe.layers.Count - 1;
+            }
+            EditorUtility.SetDirty(currentRecipe);
+        }
+
+        private void DuplicateLayer(int index)
+        {
+            if (currentRecipe == null || index < 0 || index >= currentRecipe.layers.Count)
+            {
+                return;
+            }
+
+            Undo.RecordObject(currentRecipe, "Duplicate Layer");
+            var clone = CloneLayer(currentRecipe.layers[index]);
+            currentRecipe.layers.Insert(index + 1, clone);
+            serializedRecipe.Update();
+            if (layerList != null)
+            {
+                layerList.index = index + 1;
+            }
+            EditorUtility.SetDirty(currentRecipe);
+        }
+
+        private void RemoveLayer(int index)
+        {
+            if (currentRecipe == null || index < 0 || index >= currentRecipe.layers.Count)
+            {
+                return;
+            }
+
+            Undo.RecordObject(currentRecipe, "Remove Layer");
+            currentRecipe.layers.RemoveAt(index);
+            serializedRecipe.Update();
+            if (layerList != null)
+            {
+                layerList.index = Mathf.Clamp(index, 0, currentRecipe.layers.Count - 1);
+            }
+            EditorUtility.SetDirty(currentRecipe);
+        }
+
+        private static FireworkLayer CloneLayer(FireworkLayer source)
+        {
+            var clone = new FireworkLayer
+            {
+                pattern = source.pattern,
+                starCount = source.starCount,
+                speedMin = source.speedMin,
+                speedMax = source.speedMax,
+                spread = source.spread,
+                layerColor = source.layerColor,
+                lifetime = source.lifetime,
+                radius = source.radius,
+                ringThickness = source.ringThickness,
+                palmArcCount = source.palmArcCount,
+                palmBend = source.palmBend,
+                pistilRadius = source.pistilRadius,
+                projectionMask = source.projectionMask,
+                layeredShellRadii = source.layeredShellRadii != null ? new List<float>(source.layeredShellRadii) : new List<float>()
+            };
+
+            if (source.modifiers != null)
+            {
+                foreach (var modifier in source.modifiers)
+                {
+                    if (modifier == null)
+                    {
+                        continue;
+                    }
+
+                    var instance = Object.Instantiate(modifier);
+                    instance.hideFlags = HideFlags.DontSave;
+                    clone.modifiers.Add(instance);
+                }
+            }
+
+            return clone;
+        }
+
+        private void PlayPreview()
+        {
+            if (currentRecipe == null)
+            {
+                return;
+            }
+
+            EnsurePreviewSystems();
+            previewLauncher.Recipe = currentRecipe;
+            previewLauncher.ResetAndLaunch();
+        }
+
+        private void EnsurePreviewSystems()
+        {
+            if (previewLauncher != null)
+            {
+                return;
+            }
+
+            var previewGo = new GameObject("FireworkRecipePreview")
+            {
+                hideFlags = HideFlags.HideAndDontSave
+            };
+
+            previewLauncher = previewGo.AddComponent<FireworkLauncher>();
+            previewLauncher.hideFlags = HideFlags.HideAndDontSave;
+
+            previewLift = previewGo.AddComponent<ParticleSystem>();
+            previewLift.hideFlags = HideFlags.HideAndDontSave;
+
+            previewBurst = previewGo.AddComponent<ParticleSystem>();
+            previewBurst.hideFlags = HideFlags.HideAndDontSave;
+
+            previewLight = previewGo.AddComponent<Light>();
+            previewLight.type = LightType.Point;
+            previewLight.range = 12f;
+            previewLight.hideFlags = HideFlags.HideAndDontSave;
+
+            var type = typeof(FireworkLauncher);
+            type.GetField("liftSystem", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.SetValue(previewLauncher, previewLift);
+            type.GetField("burstSystem", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.SetValue(previewLauncher, previewBurst);
+            type.GetField("bloomLight", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.SetValue(previewLauncher, previewLight);
+        }
+    }
+}

--- a/Assets/_Core/Editor/RecipeEditorWindow.cs.meta
+++ b/Assets/_Core/Editor/RecipeEditorWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b15ba9cedcc845a19f9d5c28370e0f6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Core/Editor/RecipeJsonUtility.cs
+++ b/Assets/_Core/Editor/RecipeJsonUtility.cs
@@ -1,0 +1,178 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using UnityEditor;
+using UnityEngine;
+
+namespace PyroLab.Fireworks.Editor
+{
+    public static class RecipeJsonUtility
+    {
+        private const string JsonFolderRelative = "Assets/RecipesJSON";
+        private const string AssetFolderRelative = "Assets/Recipes";
+        private const string DefaultExportName = "FireworkRecipe";
+
+        public static string JsonFolderRelativePath => JsonFolderRelative;
+        public static string AssetFolderRelativePath => AssetFolderRelative;
+
+        public static string EnsureJsonFolder()
+        {
+            string absolute = Path.GetFullPath(Path.Combine(Application.dataPath, "..", JsonFolderRelative));
+            if (!Directory.Exists(absolute))
+            {
+                Directory.CreateDirectory(absolute);
+                AssetDatabase.Refresh();
+            }
+
+            return absolute;
+        }
+
+        public static string EnsureAssetFolder()
+        {
+            string absolute = Path.GetFullPath(Path.Combine(Application.dataPath, "..", AssetFolderRelative));
+            if (!Directory.Exists(absolute))
+            {
+                Directory.CreateDirectory(absolute);
+                AssetDatabase.Refresh();
+            }
+
+            return absolute;
+        }
+
+        public static string ExportWithDialog(FireworkRecipe recipe)
+        {
+            if (recipe == null)
+            {
+                throw new ArgumentNullException(nameof(recipe));
+            }
+
+            string directory = EnsureJsonFolder();
+            string defaultName = !string.IsNullOrWhiteSpace(recipe.name) ? recipe.name : DefaultExportName;
+            string path = EditorUtility.SaveFilePanel("Export Firework Recipe", directory, defaultName, "json");
+            if (string.IsNullOrEmpty(path))
+            {
+                return null;
+            }
+
+            ExportToPath(recipe, path);
+            return path;
+        }
+
+        public static FireworkRecipe ImportAsNewAssetWithDialog()
+        {
+            string directory = EnsureJsonFolder();
+            string path = EditorUtility.OpenFilePanel("Import Firework Recipe", directory, "json");
+            if (string.IsNullOrEmpty(path))
+            {
+                return null;
+            }
+
+            return ImportAsNewAsset(path);
+        }
+
+        public static void OverwriteFromJsonWithDialog(FireworkRecipe target)
+        {
+            if (target == null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
+
+            string directory = EnsureJsonFolder();
+            string path = EditorUtility.OpenFilePanel("Import Firework Recipe", directory, "json");
+            if (string.IsNullOrEmpty(path))
+            {
+                return;
+            }
+
+            OverwriteFromJson(target, path);
+        }
+
+        public static void ExportToPath(FireworkRecipe recipe, string path)
+        {
+            if (recipe == null)
+            {
+                throw new ArgumentNullException(nameof(recipe));
+            }
+
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ArgumentException("Path cannot be null or empty.", nameof(path));
+            }
+
+            string json = recipe.ExportToJson();
+            File.WriteAllText(path, json);
+            AssetDatabase.Refresh();
+            Debug.Log($"Recipe exported to {path}");
+        }
+
+        public static FireworkRecipe ImportAsNewAsset(string jsonPath)
+        {
+            if (string.IsNullOrEmpty(jsonPath))
+            {
+                throw new ArgumentException("Path cannot be null or empty.", nameof(jsonPath));
+            }
+
+            if (!File.Exists(jsonPath))
+            {
+                throw new FileNotFoundException("Recipe JSON not found.", jsonPath);
+            }
+
+            EnsureAssetFolder();
+            string json = File.ReadAllText(jsonPath);
+            var recipe = ScriptableObject.CreateInstance<FireworkRecipe>();
+            recipe.hideFlags = HideFlags.None;
+            recipe.ImportFromJson(json);
+
+            string fileName = SanitizeFileName(Path.GetFileNameWithoutExtension(jsonPath));
+            if (string.IsNullOrEmpty(fileName))
+            {
+                fileName = DefaultExportName;
+            }
+
+            string assetPath = AssetDatabase.GenerateUniqueAssetPath(Path.Combine(AssetFolderRelative, fileName + ".asset"));
+            AssetDatabase.CreateAsset(recipe, assetPath);
+            EditorUtility.SetDirty(recipe);
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+            Debug.Log($"Imported recipe JSON as asset at {assetPath}");
+            Selection.activeObject = recipe;
+            return recipe;
+        }
+
+        public static void OverwriteFromJson(FireworkRecipe target, string jsonPath)
+        {
+            if (target == null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
+
+            if (string.IsNullOrEmpty(jsonPath))
+            {
+                throw new ArgumentException("Path cannot be null or empty.", nameof(jsonPath));
+            }
+
+            if (!File.Exists(jsonPath))
+            {
+                throw new FileNotFoundException("Recipe JSON not found.", jsonPath);
+            }
+
+            string json = File.ReadAllText(jsonPath);
+            Undo.RecordObject(target, "Import Firework Recipe");
+            target.ImportFromJson(json);
+            EditorUtility.SetDirty(target);
+            Debug.Log($"Imported recipe JSON into existing asset {target.name}");
+        }
+
+        private static string SanitizeFileName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return DefaultExportName;
+            }
+
+            string invalid = Regex.Escape(new string(Path.GetInvalidFileNameChars()));
+            string pattern = $"[{invalid}]";
+            return Regex.Replace(name, pattern, string.Empty).Trim();
+        }
+    }
+}

--- a/Assets/_Core/Editor/RecipeJsonUtility.cs.meta
+++ b/Assets/_Core/Editor/RecipeJsonUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 52a055d9c0624919bac603813108269b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Core/Runtime/FireworkSpawner.cs
+++ b/Assets/_Core/Runtime/FireworkSpawner.cs
@@ -17,6 +17,8 @@ namespace PyroLab.Fireworks
         private float timer;
         private int nextRecipeIndex;
 
+        public IReadOnlyList<FireworkRecipe> Recipes => recipes;
+
         private void Update()
         {
             if (autoLoop && recipes.Count > 0)
@@ -121,6 +123,48 @@ namespace PyroLab.Fireworks
 
             clone.timing = original.timing != null ? original.timing.Clone() : new TimingTrack();
             return clone;
+        }
+
+        public void SetActiveRecipe(FireworkRecipe recipe)
+        {
+            recipes.Clear();
+            if (recipe != null)
+            {
+                recipes.Add(recipe);
+            }
+
+            nextRecipeIndex = 0;
+            timer = 0f;
+            scaledCache.Clear();
+        }
+
+        public void SetRecipes(IEnumerable<FireworkRecipe> newRecipes)
+        {
+            recipes.Clear();
+            if (newRecipes != null)
+            {
+                foreach (var recipe in newRecipes)
+                {
+                    if (recipe != null)
+                    {
+                        recipes.Add(recipe);
+                    }
+                }
+            }
+
+            nextRecipeIndex = 0;
+            timer = 0f;
+            scaledCache.Clear();
+        }
+
+        public void LoadCatalog(RecipeCatalog catalog)
+        {
+            if (catalog == null)
+            {
+                return;
+            }
+
+            SetRecipes(catalog.Recipes);
         }
     }
 }

--- a/Assets/_Core/Runtime/UI.meta
+++ b/Assets/_Core/Runtime/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a94e3c7799424b08a97d5b0ed9ffbe8b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Core/Runtime/UI/RecipeCatalogRuntimeUI.cs
+++ b/Assets/_Core/Runtime/UI/RecipeCatalogRuntimeUI.cs
@@ -1,0 +1,219 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace PyroLab.Fireworks
+{
+    public class RecipeCatalogRuntimeUI : MonoBehaviour
+    {
+        [SerializeField] private RecipeCatalog catalog;
+        [SerializeField] private FireworkSpawner spawner;
+        [SerializeField] private FireworkLauncher launcher;
+        [SerializeField] private bool autoApplyOnSelection = true;
+
+        private string[] recipeNames = System.Array.Empty<string>();
+        private int selectedIndex;
+        private Rect windowRect = new Rect(16f, 16f, 260f, 180f);
+
+        private void Awake()
+        {
+            if (catalog == null)
+            {
+                catalog = Resources.Load<RecipeCatalog>("RecipeCatalog");
+                if (catalog == null)
+                {
+                    var catalogs = Resources.LoadAll<RecipeCatalog>(string.Empty);
+                    if (catalogs.Length > 0)
+                    {
+                        catalog = catalogs[0];
+                    }
+#if UNITY_EDITOR
+                    if (catalog == null)
+                    {
+                        catalog = AssetDatabase.LoadAssetAtPath<RecipeCatalog>("Assets/_Core/Data/RecipeCatalog.asset");
+                    }
+#endif
+                }
+            }
+
+            if (spawner == null)
+            {
+                spawner = FindObjectOfType<FireworkSpawner>();
+            }
+
+            if (launcher == null)
+            {
+                launcher = FindObjectOfType<FireworkLauncher>();
+            }
+
+            RebuildOptions();
+        }
+
+        private void OnEnable()
+        {
+            SceneManager.sceneLoaded += OnSceneLoaded;
+        }
+
+        private void OnDisable()
+        {
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+        }
+
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            if (spawner == null)
+            {
+                spawner = FindObjectOfType<FireworkSpawner>();
+            }
+
+            if (launcher == null)
+            {
+                launcher = FindObjectOfType<FireworkLauncher>();
+            }
+        }
+
+        private void RebuildOptions()
+        {
+            if (catalog == null)
+            {
+                recipeNames = System.Array.Empty<string>();
+                return;
+            }
+
+            var entries = new List<string>();
+            foreach (var recipe in catalog.Recipes)
+            {
+                entries.Add(recipe != null ? recipe.name : "(Missing Recipe)");
+            }
+
+            recipeNames = entries.ToArray();
+            selectedIndex = Mathf.Clamp(selectedIndex, 0, recipeNames.Length > 0 ? recipeNames.Length - 1 : 0);
+
+            if (autoApplyOnSelection)
+            {
+                ApplySelection();
+            }
+        }
+
+        private void OnGUI()
+        {
+            if (catalog == null || recipeNames.Length == 0)
+            {
+                return;
+            }
+
+            windowRect = GUILayout.Window(GetInstanceID(), windowRect, DrawWindowContents, "Recipe Catalog");
+        }
+
+        private void DrawWindowContents(int windowId)
+        {
+            GUILayout.BeginVertical();
+            GUILayout.Label("Select a recipe from the library.");
+            int newIndex = Mathf.Clamp(selectedIndex, 0, recipeNames.Length - 1);
+            newIndex = GUILayout.Popup(newIndex, recipeNames);
+            if (newIndex != selectedIndex)
+            {
+                selectedIndex = newIndex;
+                if (autoApplyOnSelection)
+                {
+                    ApplySelection();
+                }
+            }
+
+            autoApplyOnSelection = GUILayout.Toggle(autoApplyOnSelection, "Auto apply to spawner");
+
+            if (GUILayout.Button("Apply Recipe"))
+            {
+                ApplySelection();
+            }
+
+            if (GUILayout.Button("Launch Once"))
+            {
+                LaunchSelection();
+            }
+
+            if (GUILayout.Button("Reload Catalog"))
+            {
+                RebuildOptions();
+            }
+
+            GUILayout.EndVertical();
+            GUI.DragWindow(new Rect(0, 0, 10000, 20));
+        }
+
+        private void ApplySelection()
+        {
+            if (catalog == null || recipeNames.Length == 0)
+            {
+                return;
+            }
+
+            if (catalog.TryGetRecipe(selectedIndex, out var recipe))
+            {
+                if (spawner != null)
+                {
+                    spawner.SetActiveRecipe(recipe);
+                }
+
+                if (launcher != null)
+                {
+                    launcher.Recipe = recipe;
+                }
+            }
+        }
+
+        private void LaunchSelection()
+        {
+            if (spawner != null)
+            {
+                spawner.LaunchNext();
+            }
+            else if (launcher != null)
+            {
+                launcher.ResetAndLaunch();
+            }
+        }
+
+        public void SetCatalog(RecipeCatalog newCatalog)
+        {
+            catalog = newCatalog;
+            RebuildOptions();
+        }
+
+        public void SetSpawner(FireworkSpawner newSpawner)
+        {
+            spawner = newSpawner;
+        }
+
+        public void SetLauncher(FireworkLauncher newLauncher)
+        {
+            launcher = newLauncher;
+        }
+    }
+
+    public static class RecipeCatalogRuntimeBootstrap
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void EnsureRuntimeUI()
+        {
+            if (Object.FindObjectOfType<RecipeCatalogRuntimeUI>() != null)
+            {
+                return;
+            }
+
+            var spawner = Object.FindObjectOfType<FireworkSpawner>();
+            if (spawner == null)
+            {
+                return;
+            }
+
+            var go = new GameObject("RecipeCatalogRuntimeUI");
+            var ui = go.AddComponent<RecipeCatalogRuntimeUI>();
+            ui.SetSpawner(spawner);
+            ui.SetLauncher(Object.FindObjectOfType<FireworkLauncher>());
+        }
+    }
+}

--- a/Assets/_Core/Runtime/UI/RecipeCatalogRuntimeUI.cs.meta
+++ b/Assets/_Core/Runtime/UI/RecipeCatalogRuntimeUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d42ca03c5c245b8a967cfcc324353d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ PYRO_LAB 是一個以 Unity（建議 2022 LTS + Universal Render Pipeline）打�
 - **模組化 FireworkRecipe**：以 ScriptableObject 描述多層（Layer）煙火結構，支援拖尾、閃爍、變色、重力拖曳、分裂等 Modifier，所有內容皆為純視覺行為參數。
 - **BurstPatterns 幾何取樣**：提供球殼、柳枝、環形、棕櫚、Pistil Ring、Layered Shell、2D 投影等數學採樣函式，僅生成方向向量與比例資訊。
 - **TimingTrack 事件**：以 0~1 正規化時間定義二段爆、層級再觸發、Modifier 事件，快速搭建複合視覺節奏。
-- **Recipe Composer GUI**：改版 Inspector 具備層級排序、Modifier 選單、Timing 編輯與預覽，並保留 JSON 匯入／匯出。
+- **Recipe Composer GUI & Editor Window**：改版 Inspector 與專屬 **Recipe Editor** 視窗具備層級拖拉排序、Modifier 選單、Timing 編輯與預覽，並保留 JSON 匯入／匯出。
 - **Demo_Modular 場景**：提供至少六組預設視覺配方，可透過鍵盤快速切換並示範 Recipe Composer 操作。
 
 ## 🗂 專案結構
@@ -36,9 +36,17 @@ Assets/
       FireworkSpawner.cs
     Editor/
       FireworkRecipeEditor.cs
+      RecipeEditorWindow.cs
+      RecipeJsonUtility.cs
       JsonPresetExporter.cs
+    Data/
+      RecipeCatalog.asset
   Prefabs/
     PF_FireworkLauncher.prefab
+  Recipes/
+    (以 ScriptableObject 儲存的純視覺配方)
+  RecipesJSON/
+    (透過工具匯出的 JSON 設定)
   Scenes/
     Demo_Modular.unity
     Demo.unity (legacy)
@@ -56,14 +64,21 @@ README.md
 3. 播放場景後，使用 `FireworkSpawner` 監控物件，以空白鍵或等待自動輪播即可觀看多組預設煙火組合；鍵盤 `1~6` 可切換推薦配方。
 
 ## 🎨 建立自訂配方
-1. 於 Project 視窗中右鍵 → **Create → PYRO → Firework Recipe**。
-2. 在 Inspector 的 **Recipe Composer** 中：
+1. 於 Project 視窗中右鍵 → **Create → PYRO → Firework Recipe**，或透過選單 **PYRO → Recipe Editor** 建立並管理配方。
+2. 在 Inspector 的 **Recipe Composer** 或 Recipe Editor 視窗中：
    - 調整 Global 區塊（尺寸、預期高度、Fuse 時間、顏色漸層、HDR 強度）。
    - 依需求新增多個 Layer，為每層選擇幾何 Pattern、設定速度範圍與顏色漸層。
    - 透過 **Add Modifier** 選單套用拖尾、Strobe、Color Shift、Fade、Gravity Drag、Split、Twinkle 等純視覺效果。
    - 在 Timing Track 新增事件，組合二段爆或指定層的再觸發節奏。
 3. 使用 **Preview** 按鈕於編輯器模式播放視覺模擬。
-4. 透過 **Export JSON** / **Import JSON** 保存或載入純文字 Recipe 設定。
+4. 使用 **Preview** 或 Recipe Editor 視窗右上角的 Preview 按鈕，在不進 Play 的狀態下一次預覽。
+5. 透過 **Export JSON** / **Import JSON** 保存或載入純文字 Recipe 設定。所有匯出檔案會儲存在 `Assets/RecipesJSON/`，可再從該資料夾匯入並自動建立新的 ScriptableObject。
+
+## 📚 Recipe Catalog 與 Demo UI
+- 在 `Assets/_Core/Data/RecipeCatalog.asset` 維護配方清單，可直接拖曳 `FireworkRecipe` 進入清單並於專案內快速重複使用。
+- 執行 Demo 場景時，畫面左上角會出現簡易的 **Recipe Catalog** 視窗，可從資料庫中選擇配方、立即套用至 `FireworkSpawner` 並觸發一次發射。
+- 需要更多配方時，可將新的 `.asset` 放入 `Assets/Recipes/`，再於 Catalog 中登錄即可。
+- 匯出→刪除 `.asset`→從 JSON 匯入後，視覺結果將與原始設定一致（允許極微小數值誤差）。
 
 ## 🧭 Phase 2 擴充藍圖
 - 以日本花火風格為靈感，將「紙皮層數、星粒排列、導火延遲、特效粉末」抽象為純數值參數。


### PR DESCRIPTION
## Summary
- add a dedicated Recipe Editor window with drag-reorderable layers, preview controls, and quick JSON import/export hooks
- centralize recipe JSON serialization in `RecipeJsonUtility` and hook the existing inspector tooling into the new workflow
- introduce a recipe catalog ScriptableObject plus runtime UI helpers for the demo scene, and document the workflow in the README

## Testing
- not run (Unity editor tooling)


------
https://chatgpt.com/codex/tasks/task_e_68e031a3ee608328b887ec5fcf5a99c2