### PR TITLE
Add runtime recipe quick switch UI with validation and samples

### DIFF
--- a/Assets/RecipesJSON/Examples.meta
+++ b/Assets/RecipesJSON/Examples.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3cf40c57fcc34c6499878a2c31654b19
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/RecipesJSON/Examples/Brocade.json
+++ b/Assets/RecipesJSON/Examples/Brocade.json
@@ -1,0 +1,94 @@
+{
+  "recipeName": "Brocade Crown",
+  "size": 1.05,
+  "desiredBurstHeight": 90.0,
+  "fuseTime": 2.2,
+  "sizeOverLifetime": {
+    "keys": [
+      { "time": 0.0, "value": 0.05, "inTangent": 0.0, "outTangent": 0.8, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 },
+      { "time": 0.5, "value": 1.0, "inTangent": 0.0, "outTangent": -1.0, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 },
+      { "time": 1.0, "value": 0.1, "inTangent": 0.0, "outTangent": 0.0, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 }
+    ],
+    "preWrapMode": 1,
+    "postWrapMode": 1
+  },
+  "colorOverLifetime": {
+    "colorKeys": [
+      { "color": { "r": 1.0, "g": 0.85, "b": 0.45, "a": 1.0 }, "time": 0.0 },
+      { "color": { "r": 0.95, "g": 0.7, "b": 0.35, "a": 1.0 }, "time": 1.0 }
+    ],
+    "alphaKeys": [
+      { "alpha": 1.0, "time": 0.0 },
+      { "alpha": 0.0, "time": 1.0 }
+    ]
+  },
+  "hdrIntensity": 3.0,
+  "launchVariance": 0.14,
+  "burstSymmetry": 0.87,
+  "angularSpread": 4.5,
+  "spreadJitter": 0.06,
+  "gravityFactor": 0.24,
+  "trailLengthScale": 3.8,
+  "layers": [
+    {
+      "pattern": 5,
+      "starCount": 360,
+      "speedMin": 5.8,
+      "speedMax": 9.5,
+      "spread": 0.05,
+      "layerColor": {
+        "colorKeys": [
+          { "color": { "r": 1.0, "g": 0.85, "b": 0.45, "a": 1.0 }, "time": 0.0 },
+          { "color": { "r": 0.95, "g": 0.7, "b": 0.35, "a": 1.0 }, "time": 1.0 }
+        ],
+        "alphaKeys": [
+          { "alpha": 1.0, "time": 0.0 },
+          { "alpha": 0.0, "time": 1.0 }
+        ]
+      },
+      "lifetime": 4.0,
+      "radius": 1.0,
+      "ringThickness": 0.14,
+      "palmArcCount": 6.5,
+      "palmBend": 0.25,
+      "pistilRadius": 0.3,
+      "projectionMask": null,
+      "layeredShellRadii": [ 0.35, 0.6, 0.85, 1.0 ],
+      "modifiers": [
+        {
+          "type": "PyroLab.Fireworks.SplitModifier, Assembly-CSharp",
+          "json": "{\n    \"isEnabled\": true,\n    \"splitTime\": 0.42,\n    \"splitCount\": 3,\n    \"splitSpeed\": 5.5,\n    \"angularJitter\": 0.18\n}"
+        }
+      ]
+    },
+    {
+      "pattern": 2,
+      "starCount": 140,
+      "speedMin": 5.0,
+      "speedMax": 8.0,
+      "spread": 0.0,
+      "layerColor": {
+        "colorKeys": [
+          { "color": { "r": 1.0, "g": 0.9, "b": 0.6, "a": 1.0 }, "time": 0.0 },
+          { "color": { "r": 1.0, "g": 0.9, "b": 0.6, "a": 1.0 }, "time": 1.0 }
+        ],
+        "alphaKeys": [
+          { "alpha": 1.0, "time": 0.0 },
+          { "alpha": 0.0, "time": 1.0 }
+        ]
+      },
+      "lifetime": 3.0,
+      "radius": 0.65,
+      "ringThickness": 0.18,
+      "palmArcCount": 5.0,
+      "palmBend": 0.25,
+      "pistilRadius": 0.2,
+      "projectionMask": null,
+      "layeredShellRadii": [ 0.2, 0.4, 0.6 ],
+      "modifiers": []
+    }
+  ],
+  "timing": {
+    "events": []
+  }
+}

--- a/Assets/RecipesJSON/Examples/Brocade.json.meta
+++ b/Assets/RecipesJSON/Examples/Brocade.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1a5ddc080c1444268289b8ff18dc5325
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/RecipesJSON/Examples/Chrysanthemum.json
+++ b/Assets/RecipesJSON/Examples/Chrysanthemum.json
@@ -1,0 +1,94 @@
+{
+  "recipeName": "Chrysanthemum",
+  "size": 1.2,
+  "desiredBurstHeight": 95.0,
+  "fuseTime": 2.4,
+  "sizeOverLifetime": {
+    "keys": [
+      { "time": 0.0, "value": 0.0, "inTangent": 0.0, "outTangent": 0.9, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 },
+      { "time": 0.45, "value": 1.05, "inTangent": 0.0, "outTangent": -1.1, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 },
+      { "time": 1.0, "value": 0.0, "inTangent": 0.0, "outTangent": 0.0, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 }
+    ],
+    "preWrapMode": 1,
+    "postWrapMode": 1
+  },
+  "colorOverLifetime": {
+    "colorKeys": [
+      { "color": { "r": 0.95, "g": 0.55, "b": 0.1, "a": 1.0 }, "time": 0.0 },
+      { "color": { "r": 0.95, "g": 0.8, "b": 0.25, "a": 1.0 }, "time": 1.0 }
+    ],
+    "alphaKeys": [
+      { "alpha": 1.0, "time": 0.0 },
+      { "alpha": 0.0, "time": 1.0 }
+    ]
+  },
+  "hdrIntensity": 2.8,
+  "launchVariance": 0.15,
+  "burstSymmetry": 0.92,
+  "angularSpread": 3.6,
+  "spreadJitter": 0.04,
+  "gravityFactor": 0.22,
+  "trailLengthScale": 3.9,
+  "layers": [
+    {
+      "pattern": 0,
+      "starCount": 240,
+      "speedMin": 6.5,
+      "speedMax": 12.0,
+      "spread": 0.08,
+      "layerColor": {
+        "colorKeys": [
+          { "color": { "r": 0.95, "g": 0.55, "b": 0.1, "a": 1.0 }, "time": 0.0 },
+          { "color": { "r": 0.95, "g": 0.8, "b": 0.25, "a": 1.0 }, "time": 1.0 }
+        ],
+        "alphaKeys": [
+          { "alpha": 1.0, "time": 0.0 },
+          { "alpha": 0.0, "time": 1.0 }
+        ]
+      },
+      "lifetime": 3.8,
+      "radius": 1.0,
+      "ringThickness": 0.18,
+      "palmArcCount": 6.0,
+      "palmBend": 0.28,
+      "pistilRadius": 0.3,
+      "projectionMask": null,
+      "layeredShellRadii": [ 0.4, 0.72, 1.0 ],
+      "modifiers": [
+        {
+          "type": "PyroLab.Fireworks.TwinkleModifier, Assembly-CSharp",
+          "json": "{\n    \"isEnabled\": true,\n    \"twinkleProbability\": 0.35,\n    \"intensityVariance\": 0.45\n}"
+        }
+      ]
+    },
+    {
+      "pattern": 4,
+      "starCount": 120,
+      "speedMin": 4.5,
+      "speedMax": 7.8,
+      "spread": 0.0,
+      "layerColor": {
+        "colorKeys": [
+          { "color": { "r": 1.0, "g": 0.95, "b": 0.65, "a": 1.0 }, "time": 0.0 },
+          { "color": { "r": 1.0, "g": 0.95, "b": 0.65, "a": 1.0 }, "time": 1.0 }
+        ],
+        "alphaKeys": [
+          { "alpha": 1.0, "time": 0.0 },
+          { "alpha": 0.0, "time": 1.0 }
+        ]
+      },
+      "lifetime": 3.1,
+      "radius": 0.55,
+      "ringThickness": 0.1,
+      "palmArcCount": 4.0,
+      "palmBend": 0.2,
+      "pistilRadius": 0.2,
+      "projectionMask": null,
+      "layeredShellRadii": [ 0.25, 0.4, 0.6 ],
+      "modifiers": []
+    }
+  ],
+  "timing": {
+    "events": []
+  }
+}

--- a/Assets/RecipesJSON/Examples/Chrysanthemum.json.meta
+++ b/Assets/RecipesJSON/Examples/Chrysanthemum.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a021e359947c4a0b96d7d4f838f561ac
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/RecipesJSON/Examples/Coconut.json
+++ b/Assets/RecipesJSON/Examples/Coconut.json
@@ -1,0 +1,89 @@
+{
+  "recipeName": "Coconut",
+  "size": 1.0,
+  "desiredBurstHeight": 85.0,
+  "fuseTime": 2.0,
+  "sizeOverLifetime": {
+    "keys": [
+      { "time": 0.0, "value": 0.1, "inTangent": 0.0, "outTangent": 0.7, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 },
+      { "time": 0.48, "value": 1.0, "inTangent": 0.0, "outTangent": -1.1, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 },
+      { "time": 1.0, "value": 0.0, "inTangent": 0.0, "outTangent": 0.0, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 }
+    ],
+    "preWrapMode": 1,
+    "postWrapMode": 1
+  },
+  "colorOverLifetime": {
+    "colorKeys": [
+      { "color": { "r": 0.8, "g": 0.95, "b": 1.0, "a": 1.0 }, "time": 0.0 },
+      { "color": { "r": 0.4, "g": 0.75, "b": 1.0, "a": 1.0 }, "time": 1.0 }
+    ],
+    "alphaKeys": [
+      { "alpha": 1.0, "time": 0.0 },
+      { "alpha": 0.0, "time": 1.0 }
+    ]
+  },
+  "hdrIntensity": 2.7,
+  "launchVariance": 0.2,
+  "burstSymmetry": 0.82,
+  "angularSpread": 4.8,
+  "spreadJitter": 0.07,
+  "gravityFactor": 0.18,
+  "trailLengthScale": 3.6,
+  "layers": [
+    {
+      "pattern": 3,
+      "starCount": 260,
+      "speedMin": 6.0,
+      "speedMax": 11.0,
+      "spread": 0.1,
+      "layerColor": {
+        "colorKeys": [
+          { "color": { "r": 0.8, "g": 0.95, "b": 1.0, "a": 1.0 }, "time": 0.0 },
+          { "color": { "r": 0.4, "g": 0.75, "b": 1.0, "a": 1.0 }, "time": 1.0 }
+        ],
+        "alphaKeys": [
+          { "alpha": 1.0, "time": 0.0 },
+          { "alpha": 0.0, "time": 1.0 }
+        ]
+      },
+      "lifetime": 3.9,
+      "radius": 1.1,
+      "ringThickness": 0.22,
+      "palmArcCount": 7.0,
+      "palmBend": 0.45,
+      "pistilRadius": 0.3,
+      "projectionMask": null,
+      "layeredShellRadii": [ 0.3, 0.55, 0.8, 1.0 ],
+      "modifiers": []
+    },
+    {
+      "pattern": 0,
+      "starCount": 120,
+      "speedMin": 5.5,
+      "speedMax": 9.0,
+      "spread": 0.05,
+      "layerColor": {
+        "colorKeys": [
+          { "color": { "r": 1.0, "g": 0.9, "b": 0.55, "a": 1.0 }, "time": 0.0 },
+          { "color": { "r": 1.0, "g": 0.9, "b": 0.55, "a": 1.0 }, "time": 1.0 }
+        ],
+        "alphaKeys": [
+          { "alpha": 1.0, "time": 0.0 },
+          { "alpha": 0.0, "time": 1.0 }
+        ]
+      },
+      "lifetime": 3.2,
+      "radius": 0.7,
+      "ringThickness": 0.16,
+      "palmArcCount": 5.0,
+      "palmBend": 0.3,
+      "pistilRadius": 0.25,
+      "projectionMask": null,
+      "layeredShellRadii": [ 0.25, 0.4, 0.6 ],
+      "modifiers": []
+    }
+  ],
+  "timing": {
+    "events": []
+  }
+}

--- a/Assets/RecipesJSON/Examples/Coconut.json.meta
+++ b/Assets/RecipesJSON/Examples/Coconut.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c1f47a06fa504cac8affa41b23554c3d
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/RecipesJSON/Examples/Heart.json
+++ b/Assets/RecipesJSON/Examples/Heart.json
@@ -1,0 +1,94 @@
+{
+  "recipeName": "Heart",
+  "size": 1.1,
+  "desiredBurstHeight": 88.0,
+  "fuseTime": 2.3,
+  "sizeOverLifetime": {
+    "keys": [
+      { "time": 0.0, "value": 0.0, "inTangent": 0.0, "outTangent": 0.75, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 },
+      { "time": 0.5, "value": 1.0, "inTangent": 0.0, "outTangent": -1.0, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 },
+      { "time": 1.0, "value": 0.05, "inTangent": 0.0, "outTangent": 0.0, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 }
+    ],
+    "preWrapMode": 1,
+    "postWrapMode": 1
+  },
+  "colorOverLifetime": {
+    "colorKeys": [
+      { "color": { "r": 1.0, "g": 0.35, "b": 0.5, "a": 1.0 }, "time": 0.0 },
+      { "color": { "r": 1.0, "g": 0.65, "b": 0.75, "a": 1.0 }, "time": 1.0 }
+    ],
+    "alphaKeys": [
+      { "alpha": 1.0, "time": 0.0 },
+      { "alpha": 0.0, "time": 1.0 }
+    ]
+  },
+  "hdrIntensity": 2.9,
+  "launchVariance": 0.17,
+  "burstSymmetry": 0.84,
+  "angularSpread": 4.0,
+  "spreadJitter": 0.05,
+  "gravityFactor": 0.2,
+  "trailLengthScale": 3.4,
+  "layers": [
+    {
+      "pattern": 2,
+      "starCount": 260,
+      "speedMin": 5.5,
+      "speedMax": 9.2,
+      "spread": 0.0,
+      "layerColor": {
+        "colorKeys": [
+          { "color": { "r": 1.0, "g": 0.35, "b": 0.5, "a": 1.0 }, "time": 0.0 },
+          { "color": { "r": 1.0, "g": 0.65, "b": 0.75, "a": 1.0 }, "time": 1.0 }
+        ],
+        "alphaKeys": [
+          { "alpha": 1.0, "time": 0.0 },
+          { "alpha": 0.0, "time": 1.0 }
+        ]
+      },
+      "lifetime": 3.4,
+      "radius": 0.95,
+      "ringThickness": 0.24,
+      "palmArcCount": 4.0,
+      "palmBend": 0.35,
+      "pistilRadius": 0.22,
+      "projectionMask": null,
+      "layeredShellRadii": [ 0.35, 0.55, 0.8 ],
+      "modifiers": [
+        {
+          "type": "PyroLab.Fireworks.SplitModifier, Assembly-CSharp",
+          "json": "{\n    \"isEnabled\": true,\n    \"splitTime\": 0.38,\n    \"splitCount\": 2,\n    \"splitSpeed\": 5.0,\n    \"angularJitter\": 0.15\n}"
+        }
+      ]
+    },
+    {
+      "pattern": 0,
+      "starCount": 90,
+      "speedMin": 4.5,
+      "speedMax": 7.5,
+      "spread": 0.1,
+      "layerColor": {
+        "colorKeys": [
+          { "color": { "r": 1.0, "g": 0.8, "b": 0.9, "a": 1.0 }, "time": 0.0 },
+          { "color": { "r": 1.0, "g": 0.8, "b": 0.9, "a": 1.0 }, "time": 1.0 }
+        ],
+        "alphaKeys": [
+          { "alpha": 1.0, "time": 0.0 },
+          { "alpha": 0.0, "time": 1.0 }
+        ]
+      },
+      "lifetime": 3.0,
+      "radius": 0.5,
+      "ringThickness": 0.12,
+      "palmArcCount": 4.0,
+      "palmBend": 0.25,
+      "pistilRadius": 0.2,
+      "projectionMask": null,
+      "layeredShellRadii": [ 0.2, 0.35, 0.5 ],
+      "modifiers": []
+    }
+  ],
+  "timing": {
+    "events": []
+  }
+}

--- a/Assets/RecipesJSON/Examples/Heart.json.meta
+++ b/Assets/RecipesJSON/Examples/Heart.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d4b4ae6055f446ada4a9b4905d774ec0
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/RecipesJSON/Examples/Peony.json
+++ b/Assets/RecipesJSON/Examples/Peony.json
@@ -1,0 +1,63 @@
+{
+  "recipeName": "Peony",
+  "size": 1.0,
+  "desiredBurstHeight": 80.0,
+  "fuseTime": 2.1,
+  "sizeOverLifetime": {
+    "keys": [
+      { "time": 0.0, "value": 0.0, "inTangent": 0.0, "outTangent": 1.1, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 },
+      { "time": 0.52, "value": 1.0, "inTangent": 0.0, "outTangent": -1.5, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 },
+      { "time": 1.0, "value": 0.0, "inTangent": 0.0, "outTangent": 0.0, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 }
+    ],
+    "preWrapMode": 1,
+    "postWrapMode": 1
+  },
+  "colorOverLifetime": {
+    "colorKeys": [
+      { "color": { "r": 1.0, "g": 0.45, "b": 0.2, "a": 1.0 }, "time": 0.0 },
+      { "color": { "r": 1.0, "g": 0.82, "b": 0.32, "a": 1.0 }, "time": 1.0 }
+    ],
+    "alphaKeys": [
+      { "alpha": 1.0, "time": 0.0 },
+      { "alpha": 0.0, "time": 1.0 }
+    ]
+  },
+  "hdrIntensity": 2.6,
+  "launchVariance": 0.18,
+  "burstSymmetry": 0.88,
+  "angularSpread": 4.2,
+  "spreadJitter": 0.05,
+  "gravityFactor": 0.2,
+  "trailLengthScale": 3.5,
+  "layers": [
+    {
+      "pattern": 0,
+      "starCount": 280,
+      "speedMin": 6.0,
+      "speedMax": 10.5,
+      "spread": 0.12,
+      "layerColor": {
+        "colorKeys": [
+          { "color": { "r": 1.0, "g": 0.45, "b": 0.2, "a": 1.0 }, "time": 0.0 },
+          { "color": { "r": 1.0, "g": 0.82, "b": 0.32, "a": 1.0 }, "time": 1.0 }
+        ],
+        "alphaKeys": [
+          { "alpha": 1.0, "time": 0.0 },
+          { "alpha": 0.0, "time": 1.0 }
+        ]
+      },
+      "lifetime": 3.6,
+      "radius": 1.0,
+      "ringThickness": 0.15,
+      "palmArcCount": 5.0,
+      "palmBend": 0.3,
+      "pistilRadius": 0.35,
+      "projectionMask": null,
+      "layeredShellRadii": [ 0.4, 0.75, 1.0 ],
+      "modifiers": []
+    }
+  ],
+  "timing": {
+    "events": []
+  }
+}

--- a/Assets/RecipesJSON/Examples/Peony.json.meta
+++ b/Assets/RecipesJSON/Examples/Peony.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 41c2ed6043ea40c38f6b6b62684c49bb
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/RecipesJSON/Examples/Willow.json
+++ b/Assets/RecipesJSON/Examples/Willow.json
@@ -1,0 +1,94 @@
+{
+  "recipeName": "Willow",
+  "size": 1.15,
+  "desiredBurstHeight": 110.0,
+  "fuseTime": 2.8,
+  "sizeOverLifetime": {
+    "keys": [
+      { "time": 0.0, "value": 0.0, "inTangent": 0.0, "outTangent": 0.85, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 },
+      { "time": 0.4, "value": 1.0, "inTangent": 0.0, "outTangent": -0.9, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 },
+      { "time": 1.0, "value": 0.05, "inTangent": 0.0, "outTangent": 0.0, "tangentMode": 0, "weightedMode": 0, "inWeight": 0.33333334, "outWeight": 0.33333334 }
+    ],
+    "preWrapMode": 1,
+    "postWrapMode": 1
+  },
+  "colorOverLifetime": {
+    "colorKeys": [
+      { "color": { "r": 1.0, "g": 0.9, "b": 0.6, "a": 1.0 }, "time": 0.0 },
+      { "color": { "r": 0.95, "g": 0.75, "b": 0.4, "a": 1.0 }, "time": 1.0 }
+    ],
+    "alphaKeys": [
+      { "alpha": 1.0, "time": 0.0 },
+      { "alpha": 0.0, "time": 1.0 }
+    ]
+  },
+  "hdrIntensity": 2.9,
+  "launchVariance": 0.16,
+  "burstSymmetry": 0.8,
+  "angularSpread": 5.0,
+  "spreadJitter": 0.08,
+  "gravityFactor": 0.28,
+  "trailLengthScale": 4.4,
+  "layers": [
+    {
+      "pattern": 1,
+      "starCount": 420,
+      "speedMin": 5.2,
+      "speedMax": 8.6,
+      "spread": 0.18,
+      "layerColor": {
+        "colorKeys": [
+          { "color": { "r": 1.0, "g": 0.9, "b": 0.6, "a": 1.0 }, "time": 0.0 },
+          { "color": { "r": 0.95, "g": 0.75, "b": 0.4, "a": 1.0 }, "time": 1.0 }
+        ],
+        "alphaKeys": [
+          { "alpha": 1.0, "time": 0.0 },
+          { "alpha": 0.0, "time": 1.0 }
+        ]
+      },
+      "lifetime": 4.6,
+      "radius": 1.1,
+      "ringThickness": 0.2,
+      "palmArcCount": 6.0,
+      "palmBend": 0.4,
+      "pistilRadius": 0.25,
+      "projectionMask": null,
+      "layeredShellRadii": [ 0.35, 0.65, 1.0 ],
+      "modifiers": [
+        {
+          "type": "PyroLab.Fireworks.TrailModifier, Assembly-CSharp",
+          "json": "{\n    \\"isEnabled\\": true,\n    \\"lengthScale\\": 5.0,\n    \\"velocityStretch\\": 0.75\n}"
+        }
+      ]
+    },
+    {
+      "pattern": 4,
+      "starCount": 80,
+      "speedMin": 4.0,
+      "speedMax": 6.5,
+      "spread": 0.0,
+      "layerColor": {
+        "colorKeys": [
+          { "color": { "r": 1.0, "g": 0.85, "b": 0.5, "a": 1.0 }, "time": 0.0 },
+          { "color": { "r": 1.0, "g": 0.85, "b": 0.5, "a": 1.0 }, "time": 1.0 }
+        ],
+        "alphaKeys": [
+          { "alpha": 1.0, "time": 0.0 },
+          { "alpha": 0.0, "time": 1.0 }
+        ]
+      },
+      "lifetime": 3.5,
+      "radius": 0.4,
+      "ringThickness": 0.12,
+      "palmArcCount": 3.0,
+      "palmBend": 0.2,
+      "pistilRadius": 0.18,
+      "projectionMask": null,
+      "layeredShellRadii": [ 0.2, 0.35, 0.5 ],
+      "modifiers": []
+    }
+  ],
+  "timing": {
+    "events": []
+  }
+}

--- a/Assets/RecipesJSON/Examples/Willow.json.meta
+++ b/Assets/RecipesJSON/Examples/Willow.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 724a4960e99f4fb3bc3733cbe4221572
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Core/Editor/RecipeJsonUtility.cs
+++ b/Assets/_Core/Editor/RecipeJsonUtility.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
@@ -14,6 +16,161 @@ namespace PyroLab.Fireworks.Editor
 
         public static string JsonFolderRelativePath => JsonFolderRelative;
         public static string AssetFolderRelativePath => AssetFolderRelative;
+
+        public readonly struct RecipeValidationSummary
+        {
+            public readonly string RecipeName;
+            public readonly int LayerCount;
+            public readonly int TotalStarCount;
+            public readonly int PeakParticleEstimate;
+            public readonly int EstimatedDrawCalls;
+            public readonly float TotalParticleLifetime;
+
+            public RecipeValidationSummary(string recipeName, int layerCount, int totalStarCount, int peakParticleEstimate, int estimatedDrawCalls, float totalParticleLifetime)
+            {
+                RecipeName = recipeName;
+                LayerCount = layerCount;
+                TotalStarCount = totalStarCount;
+                PeakParticleEstimate = peakParticleEstimate;
+                EstimatedDrawCalls = estimatedDrawCalls;
+                TotalParticleLifetime = totalParticleLifetime;
+            }
+        }
+
+        public static bool Validate(string json)
+        {
+            return Validate(json, null, out _);
+        }
+
+        public static bool Validate(string json, string sourceLabel, out RecipeValidationSummary summary)
+        {
+            summary = default;
+
+            string context = string.IsNullOrEmpty(sourceLabel) ? "Recipe JSON" : $"Recipe JSON ({sourceLabel})";
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                Debug.LogError($"{context}: Content is empty.");
+                return false;
+            }
+
+            Dictionary<string, object> root;
+            try
+            {
+                root = SimpleJson.Parse(json) as Dictionary<string, object>;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"{context}: Failed to parse JSON. {ex.Message}");
+                return false;
+            }
+
+            if (root == null)
+            {
+                Debug.LogError($"{context}: Root JSON object is invalid.");
+                return false;
+            }
+
+            var errors = new List<string>();
+            var warnings = new List<string>();
+
+            root.TryGetValue("recipeName", out var nameObj);
+            string recipeName = nameObj as string;
+
+            ValidateNumber(root, "size", context, errors, warnings, allowZero: false, allowNegative: false);
+            ValidateNumber(root, "desiredBurstHeight", context, errors, warnings, allowZero: true, allowNegative: false);
+            ValidateNumber(root, "fuseTime", context, errors, warnings, allowZero: false, allowNegative: false);
+
+            int layerCount = 0;
+            int totalStars = 0;
+            int peakParticles = 0;
+            int drawCalls = 0;
+            float totalLifetime = 0f;
+
+            if (!root.TryGetValue("layers", out var layersObj) || layersObj is not List<object> layersList)
+            {
+                errors.Add("Missing 'layers' array.");
+            }
+            else if (layersList.Count == 0)
+            {
+                warnings.Add("Recipe contains no layers.");
+            }
+            else
+            {
+                for (int i = 0; i < layersList.Count; i++)
+                {
+                    if (layersList[i] is not Dictionary<string, object> layerDict)
+                    {
+                        errors.Add($"Layer {i}: Invalid entry format.");
+                        continue;
+                    }
+
+                    layerCount++;
+                    drawCalls++;
+
+                    int starCount = ReadInt(layerDict, "starCount", errors, context, i, minimum: 0);
+                    totalStars += Mathf.Max(0, starCount);
+
+                    double lifetimeValue = ReadNumber(layerDict, "lifetime", errors, context, i, allowZero: true, allowNegative: false);
+
+                    ValidateNumber(layerDict, "speedMin", context, errors, warnings, allowZero: false, allowNegative: false, layerIndex: i);
+                    ValidateNumber(layerDict, "speedMax", context, errors, warnings, allowZero: false, allowNegative: false, layerIndex: i);
+
+                    int multiplier = 1;
+                    bool hasTrails = false;
+
+                    if (layerDict.TryGetValue("modifiers", out var modifiersObj) && modifiersObj is List<object> modifiersList)
+                    {
+                        foreach (var modifierObj in modifiersList)
+                        {
+                            if (modifierObj is not Dictionary<string, object> modifierDict)
+                            {
+                                warnings.Add($"Layer {i}: Modifier entry is malformed.");
+                                continue;
+                            }
+
+                            string typeName = ReadString(modifierDict, "type");
+                            if (string.IsNullOrEmpty(typeName))
+                            {
+                                warnings.Add($"Layer {i}: Modifier type missing.");
+                                continue;
+                            }
+
+                            if (typeName.Contains("SplitModifier"))
+                            {
+                                int splitCount = ExtractSplitCount(modifierDict, context, errors, i);
+                                multiplier = Mathf.Max(multiplier, splitCount);
+                            }
+                            else if (typeName.Contains("TrailModifier"))
+                            {
+                                hasTrails = true;
+                            }
+                        }
+                    }
+
+                    peakParticles += Mathf.Max(0, starCount) * Mathf.Max(1, multiplier);
+                    totalLifetime += Mathf.Max(0, starCount) * Mathf.Max(1, multiplier) * Mathf.Max(0f, (float)lifetimeValue);
+
+                    if (hasTrails)
+                    {
+                        drawCalls += 1;
+                    }
+                }
+            }
+
+            foreach (var error in errors)
+            {
+                Debug.LogError($"{context}: {error}");
+            }
+
+            foreach (var warning in warnings)
+            {
+                Debug.LogWarning($"{context}: {warning}");
+            }
+
+            bool isValid = errors.Count == 0;
+            summary = new RecipeValidationSummary(recipeName, layerCount, totalStars, peakParticles, drawCalls, totalLifetime);
+            return isValid;
+        }
 
         public static string EnsureJsonFolder()
         {
@@ -100,9 +257,10 @@ namespace PyroLab.Fireworks.Editor
             }
 
             string json = recipe.ExportToJson();
+            var summary = CreateSummaryFromRecipe(recipe);
             File.WriteAllText(path, json);
             AssetDatabase.Refresh();
-            Debug.Log($"Recipe exported to {path}");
+            LogRecipeStatistics("Export", path, summary);
         }
 
         public static FireworkRecipe ImportAsNewAsset(string jsonPath)
@@ -119,6 +277,11 @@ namespace PyroLab.Fireworks.Editor
 
             EnsureAssetFolder();
             string json = File.ReadAllText(jsonPath);
+            if (!Validate(json, jsonPath, out var validationSummary))
+            {
+                return null;
+            }
+
             var recipe = ScriptableObject.CreateInstance<FireworkRecipe>();
             recipe.hideFlags = HideFlags.None;
             recipe.ImportFromJson(json);
@@ -134,6 +297,8 @@ namespace PyroLab.Fireworks.Editor
             EditorUtility.SetDirty(recipe);
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
+            var summary = CreateSummaryFromRecipe(recipe, validationSummary);
+            LogRecipeStatistics("Import", jsonPath, summary);
             Debug.Log($"Imported recipe JSON as asset at {assetPath}");
             Selection.activeObject = recipe;
             return recipe;
@@ -157,9 +322,16 @@ namespace PyroLab.Fireworks.Editor
             }
 
             string json = File.ReadAllText(jsonPath);
+            if (!Validate(json, jsonPath, out var validationSummary))
+            {
+                return;
+            }
+
             Undo.RecordObject(target, "Import Firework Recipe");
             target.ImportFromJson(json);
             EditorUtility.SetDirty(target);
+            var summary = CreateSummaryFromRecipe(target, validationSummary);
+            LogRecipeStatistics("Import", jsonPath, summary);
             Debug.Log($"Imported recipe JSON into existing asset {target.name}");
         }
 
@@ -173,6 +345,447 @@ namespace PyroLab.Fireworks.Editor
             string invalid = Regex.Escape(new string(Path.GetInvalidFileNameChars()));
             string pattern = $"[{invalid}]";
             return Regex.Replace(name, pattern, string.Empty).Trim();
+        }
+
+        private static RecipeValidationSummary CreateSummaryFromRecipe(FireworkRecipe recipe)
+        {
+            var estimate = RecipeCostUtility.Estimate(recipe);
+            string recipeName = recipe != null ? recipe.name : string.Empty;
+            return new RecipeValidationSummary(recipeName, estimate.LayerCount, estimate.TotalStarCount, estimate.EstimatedPeakParticles, estimate.EstimatedDrawCalls, estimate.TotalParticleLifetime);
+        }
+
+        private static RecipeValidationSummary CreateSummaryFromRecipe(FireworkRecipe recipe, RecipeValidationSummary validation)
+        {
+            var estimate = RecipeCostUtility.Estimate(recipe);
+            string recipeName = !string.IsNullOrEmpty(validation.RecipeName) ? validation.RecipeName : recipe != null ? recipe.name : string.Empty;
+            return new RecipeValidationSummary(recipeName, estimate.LayerCount, estimate.TotalStarCount, estimate.EstimatedPeakParticles, estimate.EstimatedDrawCalls, estimate.TotalParticleLifetime);
+        }
+
+        private static void LogRecipeStatistics(string action, string contextPath, RecipeValidationSummary summary)
+        {
+            string name = string.IsNullOrEmpty(summary.RecipeName) ? "(Unnamed Recipe)" : summary.RecipeName;
+            string location = string.IsNullOrEmpty(contextPath) ? string.Empty : $" | Source: {contextPath}";
+            Debug.Log($"[Recipe {action}] {name} | Layers: {summary.LayerCount} | Stars: {summary.TotalStarCount} | Peak Particles: {summary.PeakParticleEstimate} | Draw Calls: {summary.EstimatedDrawCalls} | Lifetime Sum: {summary.TotalParticleLifetime:F1}{location}");
+        }
+
+        private static void ValidateNumber(Dictionary<string, object> source, string key, string context, List<string> errors, List<string> warnings, bool allowZero, bool allowNegative, int layerIndex = -1)
+        {
+            double value = ReadNumber(source, key, errors, context, layerIndex, allowZero, allowNegative);
+            if (double.IsNaN(value))
+            {
+                return;
+            }
+
+            if (allowZero && Math.Abs(value) < float.Epsilon)
+            {
+                string prefix = layerIndex >= 0 ? $"Layer {layerIndex}:" : string.Empty;
+                warnings.Add($"{prefix} '{key}' is zero.");
+            }
+        }
+
+        private static double ReadNumber(Dictionary<string, object> source, string key, List<string> errors, string context, int layerIndex, bool allowZero, bool allowNegative)
+        {
+            if (!source.TryGetValue(key, out var raw))
+            {
+                string prefix = layerIndex >= 0 ? $"Layer {layerIndex}:" : string.Empty;
+                errors.Add($"{prefix} Missing '{key}'.");
+                return double.NaN;
+            }
+
+            if (!TryConvertToDouble(raw, out double value))
+            {
+                string prefix = layerIndex >= 0 ? $"Layer {layerIndex}:" : string.Empty;
+                errors.Add($"{prefix} '{key}' is not a number.");
+                return double.NaN;
+            }
+
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                string prefix = layerIndex >= 0 ? $"Layer {layerIndex}:" : string.Empty;
+                errors.Add($"{prefix} '{key}' contains an invalid numeric value.");
+                return double.NaN;
+            }
+
+            if (!allowNegative && value < 0)
+            {
+                string prefix = layerIndex >= 0 ? $"Layer {layerIndex}:" : string.Empty;
+                errors.Add($"{prefix} '{key}' cannot be negative.");
+            }
+
+            if (!allowZero && Math.Abs(value) < float.Epsilon)
+            {
+                string prefix = layerIndex >= 0 ? $"Layer {layerIndex}:" : string.Empty;
+                errors.Add($"{prefix} '{key}' cannot be zero.");
+            }
+
+            return value;
+        }
+
+        private static int ReadInt(Dictionary<string, object> source, string key, List<string> errors, string context, int layerIndex, int minimum)
+        {
+            if (!source.TryGetValue(key, out var raw))
+            {
+                errors.Add($"Layer {layerIndex}: Missing '{key}'.");
+                return 0;
+            }
+
+            if (!TryConvertToDouble(raw, out double value))
+            {
+                errors.Add($"Layer {layerIndex}: '{key}' is not numeric.");
+                return 0;
+            }
+
+            int result = Mathf.RoundToInt((float)value);
+            if (result < minimum)
+            {
+                errors.Add($"Layer {layerIndex}: '{key}' must be >= {minimum}.");
+            }
+
+            return result;
+        }
+
+        private static string ReadString(Dictionary<string, object> source, string key)
+        {
+            if (!source.TryGetValue(key, out var raw))
+            {
+                return null;
+            }
+
+            return raw as string;
+        }
+
+        private static int ExtractSplitCount(Dictionary<string, object> modifierDict, string context, List<string> errors, int layerIndex)
+        {
+            if (!modifierDict.TryGetValue("json", out var jsonObj) || jsonObj is not string json)
+            {
+                errors.Add($"Layer {layerIndex}: Split modifier missing payload.");
+                return 1;
+            }
+
+            try
+            {
+                if (SimpleJson.Parse(json) is Dictionary<string, object> payload)
+                {
+                    if (payload.TryGetValue("splitCount", out var splitValue) && TryConvertToDouble(splitValue, out double raw))
+                    {
+                        return Mathf.Max(1, Mathf.RoundToInt((float)raw));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"Layer {layerIndex}: Failed to parse split modifier payload. {ex.Message}");
+            }
+
+            return 1;
+        }
+
+        private static bool TryConvertToDouble(object value, out double result)
+        {
+            switch (value)
+            {
+                case double d:
+                    result = d;
+                    return true;
+                case float f:
+                    result = f;
+                    return true;
+                case int i:
+                    result = i;
+                    return true;
+                case long l:
+                    result = l;
+                    return true;
+                case string s when double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed):
+                    result = parsed;
+                    return true;
+                default:
+                    result = 0;
+                    return false;
+            }
+        }
+
+        private static class SimpleJson
+        {
+            public static object Parse(string json)
+            {
+                if (json == null)
+                {
+                    throw new ArgumentNullException(nameof(json));
+                }
+
+                var parser = new Parser(json);
+                return parser.ParseValue();
+            }
+
+            private sealed class Parser
+            {
+                private readonly string json;
+                private int index;
+
+                public Parser(string json)
+                {
+                    this.json = json;
+                    index = 0;
+                }
+
+                public object ParseValue()
+                {
+                    SkipWhitespace();
+                    if (index >= json.Length)
+                    {
+                        throw new FormatException("Unexpected end of JSON.");
+                    }
+
+                    char c = json[index];
+                    return c switch
+                    {
+                        '{' => ParseObject(),
+                        '[' => ParseArray(),
+                        '"' => ParseString(),
+                        't' => ParseLiteral("true", true),
+                        'f' => ParseLiteral("false", false),
+                        'n' => ParseNull(),
+                        '-' => ParseNumber(),
+                        _ when char.IsDigit(c) => ParseNumber(),
+                        _ => throw new FormatException($"Unexpected character '{c}' at position {index}.")
+                    };
+                }
+
+                private Dictionary<string, object> ParseObject()
+                {
+                    var result = new Dictionary<string, object>();
+                    index++; // skip '{'
+                    SkipWhitespace();
+
+                    if (index < json.Length && json[index] == '}')
+                    {
+                        index++;
+                        return result;
+                    }
+
+                    while (true)
+                    {
+                        SkipWhitespace();
+                        string key = ParseString();
+                        SkipWhitespace();
+
+                        if (index >= json.Length || json[index] != ':')
+                        {
+                            throw new FormatException("Expected ':' after object key.");
+                        }
+
+                        index++;
+                        object value = ParseValue();
+                        result[key] = value;
+
+                        SkipWhitespace();
+                        if (index >= json.Length)
+                        {
+                            throw new FormatException("Unterminated object.");
+                        }
+
+                        char c = json[index++];
+                        if (c == '}')
+                        {
+                            break;
+                        }
+
+                        if (c != ',')
+                        {
+                            throw new FormatException($"Unexpected character '{c}' in object.");
+                        }
+                    }
+
+                    return result;
+                }
+
+                private List<object> ParseArray()
+                {
+                    var result = new List<object>();
+                    index++; // skip '['
+                    SkipWhitespace();
+
+                    if (index < json.Length && json[index] == ']')
+                    {
+                        index++;
+                        return result;
+                    }
+
+                    while (true)
+                    {
+                        object value = ParseValue();
+                        result.Add(value);
+                        SkipWhitespace();
+                        if (index >= json.Length)
+                        {
+                            throw new FormatException("Unterminated array.");
+                        }
+
+                        char c = json[index++];
+                        if (c == ']')
+                        {
+                            break;
+                        }
+
+                        if (c != ',')
+                        {
+                            throw new FormatException($"Unexpected character '{c}' in array.");
+                        }
+                    }
+
+                    return result;
+                }
+
+                private string ParseString()
+                {
+                    if (json[index] != '"')
+                    {
+                        throw new FormatException("Expected string opening quote.");
+                    }
+
+                    index++; // skip '"'
+                    int start = index;
+                    var result = new System.Text.StringBuilder();
+
+                    while (index < json.Length)
+                    {
+                        char c = json[index++];
+                        if (c == '"')
+                        {
+                            return result.ToString();
+                        }
+
+                        if (c == '\\')
+                        {
+                            if (index >= json.Length)
+                            {
+                                throw new FormatException("Unterminated escape sequence in string.");
+                            }
+
+                            char escape = json[index++];
+                            switch (escape)
+                            {
+                                case '\"':
+                                    result.Append('"');
+                                    break;
+                                case '\\':
+                                    result.Append('\\');
+                                    break;
+                                case '/':
+                                    result.Append('/');
+                                    break;
+                                case 'b':
+                                    result.Append('\b');
+                                    break;
+                                case 'f':
+                                    result.Append('\f');
+                                    break;
+                                case 'n':
+                                    result.Append('\n');
+                                    break;
+                                case 'r':
+                                    result.Append('\r');
+                                    break;
+                                case 't':
+                                    result.Append('\t');
+                                    break;
+                                case 'u':
+                                    if (index + 4 > json.Length)
+                                    {
+                                        throw new FormatException("Invalid unicode escape sequence.");
+                                    }
+
+                                    string hex = json.Substring(index, 4);
+                                    if (!ushort.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out ushort code))
+                                    {
+                                        throw new FormatException("Invalid unicode escape sequence.");
+                                    }
+
+                                    result.Append((char)code);
+                                    index += 4;
+                                    break;
+                                default:
+                                    throw new FormatException($"Invalid escape character '{escape}'.");
+                            }
+                        }
+                        else
+                        {
+                            result.Append(c);
+                        }
+                    }
+
+                    throw new FormatException("Unterminated string literal.");
+                }
+
+                private object ParseLiteral(string literal, object value)
+                {
+                    if (json.Length - index < literal.Length || json.Substring(index, literal.Length) != literal)
+                    {
+                        throw new FormatException($"Invalid literal starting at position {index}.");
+                    }
+
+                    index += literal.Length;
+                    return value;
+                }
+
+                private object ParseNull()
+                {
+                    return ParseLiteral("null", null);
+                }
+
+                private object ParseNumber()
+                {
+                    int start = index;
+                    if (json[index] == '-')
+                    {
+                        index++;
+                    }
+
+                    while (index < json.Length && char.IsDigit(json[index]))
+                    {
+                        index++;
+                    }
+
+                    if (index < json.Length && json[index] == '.')
+                    {
+                        index++;
+                        while (index < json.Length && char.IsDigit(json[index]))
+                        {
+                            index++;
+                        }
+                    }
+
+                    if (index < json.Length && (json[index] == 'e' || json[index] == 'E'))
+                    {
+                        index++;
+                        if (index < json.Length && (json[index] == '+' || json[index] == '-'))
+                        {
+                            index++;
+                        }
+                        while (index < json.Length && char.IsDigit(json[index]))
+                        {
+                            index++;
+                        }
+                    }
+
+                    string number = json.Substring(start, index - start);
+                    if (!double.TryParse(number, NumberStyles.Float, CultureInfo.InvariantCulture, out double value))
+                    {
+                        throw new FormatException($"Invalid number '{number}'.");
+                    }
+
+                    return value;
+                }
+
+                private void SkipWhitespace()
+                {
+                    while (index < json.Length && char.IsWhiteSpace(json[index]))
+                    {
+                        index++;
+                    }
+                }
+            }
         }
     }
 }

--- a/Assets/_Core/Runtime/FireworkSpawner.cs
+++ b/Assets/_Core/Runtime/FireworkSpawner.cs
@@ -166,5 +166,10 @@ namespace PyroLab.Fireworks
 
             SetRecipes(catalog.Recipes);
         }
+
+        public RecipeCostEstimate EstimateCost(FireworkRecipe recipe)
+        {
+            return RecipeCostUtility.Estimate(recipe);
+        }
     }
 }

--- a/Assets/_Core/Runtime/RecipeCostUtility.cs
+++ b/Assets/_Core/Runtime/RecipeCostUtility.cs
@@ -1,0 +1,93 @@
+using UnityEngine;
+
+namespace PyroLab.Fireworks
+{
+    public readonly struct RecipeCostEstimate
+    {
+        public readonly int LayerCount;
+        public readonly int TotalStarCount;
+        public readonly int EstimatedPeakParticles;
+        public readonly int EstimatedDrawCalls;
+        public readonly float TotalParticleLifetime;
+
+        public RecipeCostEstimate(int layerCount, int totalStarCount, int estimatedPeakParticles, int estimatedDrawCalls, float totalParticleLifetime)
+        {
+            LayerCount = layerCount;
+            TotalStarCount = totalStarCount;
+            EstimatedPeakParticles = estimatedPeakParticles;
+            EstimatedDrawCalls = estimatedDrawCalls;
+            TotalParticleLifetime = totalParticleLifetime;
+        }
+    }
+
+    public static class RecipeCostUtility
+    {
+        private const int TrailAdditionalDrawCalls = 1;
+
+        public static RecipeCostEstimate Estimate(FireworkRecipe recipe)
+        {
+            if (recipe == null)
+            {
+                return new RecipeCostEstimate(0, 0, 0, 0, 0f);
+            }
+
+            int layerCount = 0;
+            int totalStars = 0;
+            int peakParticles = 0;
+            int drawCalls = 0;
+            float totalLifetime = 0f;
+
+            var layers = recipe.layers;
+            if (layers != null)
+            {
+                foreach (var layer in layers)
+                {
+                    if (layer == null)
+                    {
+                        continue;
+                    }
+
+                    layerCount++;
+                    drawCalls++;
+
+                    int starCount = Mathf.Max(0, layer.starCount);
+                    totalStars += starCount;
+
+                    int multiplier = 1;
+                    bool hasTrails = false;
+
+                    if (layer.modifiers != null)
+                    {
+                        foreach (var modifier in layer.modifiers)
+                        {
+                            if (modifier == null || !modifier.isEnabled)
+                            {
+                                continue;
+                            }
+
+                            switch (modifier)
+                            {
+                                case SplitModifier split:
+                                    multiplier = Mathf.Max(multiplier, Mathf.Max(1, split.splitCount));
+                                    break;
+                                case TrailModifier:
+                                    hasTrails = true;
+                                    break;
+                            }
+                        }
+                    }
+
+                    peakParticles += starCount * multiplier;
+                    totalLifetime += starCount * multiplier * Mathf.Max(0f, layer.lifetime);
+
+                    if (hasTrails)
+                    {
+                        drawCalls += TrailAdditionalDrawCalls;
+                    }
+                }
+            }
+
+            return new RecipeCostEstimate(layerCount, totalStars, peakParticles, drawCalls, totalLifetime);
+        }
+    }
+}

--- a/Assets/_Core/Runtime/RecipeCostUtility.cs.meta
+++ b/Assets/_Core/Runtime/RecipeCostUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d64d33fbfee40079df1f6eb605554f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Core/Runtime/UI/RecipeQuickUI.cs
+++ b/Assets/_Core/Runtime/UI/RecipeQuickUI.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+namespace PyroLab.Fireworks
+{
+    public class RecipeQuickUI : MonoBehaviour
+    {
+        [SerializeField] private FireworkSpawner spawner;
+        [SerializeField] private string examplesFolderRelative = "RecipesJSON/Examples";
+        [SerializeField] private float warningParticleThreshold = 300000f;
+        [SerializeField] private bool autoApplyOnStart = true;
+
+        private readonly List<ExampleEntry> examples = new();
+        private string[] optionNames = Array.Empty<string>();
+        private int selectedIndex;
+        private Vector2 scrollPosition;
+        private Rect windowRect = new Rect(0f, 0f, 340f, 320f);
+        private bool windowPositionInitialized;
+        private bool hasLoaded;
+
+        private class ExampleEntry
+        {
+            public string DisplayName;
+            public string FilePath;
+            public string DefaultJson;
+            public FireworkRecipe RecipeInstance;
+            public RecipeCostEstimate Estimate;
+        }
+
+        private void Awake()
+        {
+            if (spawner == null)
+            {
+                spawner = FindObjectOfType<FireworkSpawner>();
+            }
+
+            LoadExamples();
+        }
+
+        private void OnEnable()
+        {
+            if (!hasLoaded)
+            {
+                LoadExamples();
+            }
+        }
+
+        private void OnDestroy()
+        {
+            DisposeExamples();
+        }
+
+        private void LoadExamples()
+        {
+            DisposeExamples();
+            examples.Clear();
+            optionNames = Array.Empty<string>();
+            hasLoaded = true;
+
+            string basePath = Path.Combine(Application.dataPath, examplesFolderRelative);
+            if (!Directory.Exists(basePath))
+            {
+                Debug.LogWarning($"RecipeQuickUI: Examples folder not found at {basePath}.");
+                return;
+            }
+
+            var files = Directory.GetFiles(basePath, "*.json", SearchOption.TopDirectoryOnly);
+            Array.Sort(files, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var file in files)
+            {
+                try
+                {
+                    string json = File.ReadAllText(file);
+                    var recipe = ScriptableObject.CreateInstance<FireworkRecipe>();
+                    recipe.hideFlags = HideFlags.DontSave;
+                    recipe.ImportFromJson(json);
+
+                    var entry = new ExampleEntry
+                    {
+                        DisplayName = Path.GetFileNameWithoutExtension(file),
+                        FilePath = file,
+                        DefaultJson = json,
+                        RecipeInstance = recipe,
+                        Estimate = RecipeCostUtility.Estimate(recipe)
+                    };
+
+                    examples.Add(entry);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"RecipeQuickUI: Failed to load example '{file}'. {ex.Message}");
+                }
+            }
+
+            optionNames = new string[examples.Count];
+            for (int i = 0; i < examples.Count; i++)
+            {
+                optionNames[i] = examples[i].DisplayName;
+            }
+
+            selectedIndex = Mathf.Clamp(selectedIndex, 0, Mathf.Max(0, examples.Count - 1));
+
+            if (autoApplyOnStart && examples.Count > 0)
+            {
+                ApplySelectedRecipe();
+            }
+        }
+
+        private void DisposeExamples()
+        {
+            foreach (var entry in examples)
+            {
+                if (entry?.RecipeInstance == null)
+                {
+                    continue;
+                }
+
+                if (Application.isPlaying)
+                {
+                    Destroy(entry.RecipeInstance);
+                }
+                else
+                {
+                    DestroyImmediate(entry.RecipeInstance);
+                }
+            }
+        }
+
+        private void OnGUI()
+        {
+            if (examples.Count == 0)
+            {
+                return;
+            }
+
+            if (!windowPositionInitialized)
+            {
+                windowRect.x = Screen.width - windowRect.width - 16f;
+                windowRect.y = 16f;
+                windowPositionInitialized = true;
+            }
+
+            windowRect = GUILayout.Window(GetInstanceID(), windowRect, DrawWindowContents, "Recipe Quick Switch");
+        }
+
+        private void DrawWindowContents(int windowId)
+        {
+            GUILayout.BeginVertical();
+
+            int newIndex = examples.Count > 0 ? GUILayout.Popup(selectedIndex, optionNames) : selectedIndex;
+            if (newIndex != selectedIndex)
+            {
+                selectedIndex = newIndex;
+                ApplySelectedRecipe();
+            }
+
+            GUILayout.BeginHorizontal();
+            if (GUILayout.Button("Reload"))
+            {
+                LoadExamples();
+                GUI.FocusControl(null);
+            }
+
+            GUI.enabled = examples.Count > 0;
+            if (GUILayout.Button("Reset"))
+            {
+                ResetSelectedRecipe();
+            }
+            GUI.enabled = true;
+            GUILayout.EndHorizontal();
+
+            if (examples.Count > 0)
+            {
+                var entry = examples[selectedIndex];
+                GUILayout.Label($"Name: {entry.DisplayName}");
+                GUILayout.Label($"Path: {entry.FilePath}");
+
+                scrollPosition = GUILayout.BeginScrollView(scrollPosition, GUILayout.Height(140f));
+                if (entry.RecipeInstance != null && entry.RecipeInstance.layers != null)
+                {
+                    for (int i = 0; i < entry.RecipeInstance.layers.Count; i++)
+                    {
+                        var layer = entry.RecipeInstance.layers[i];
+                        if (layer == null)
+                        {
+                            continue;
+                        }
+
+                        string modifierSummary = "None";
+                        if (layer.modifiers != null && layer.modifiers.Count > 0)
+                        {
+                            var modifierNames = new List<string>();
+                            foreach (var modifier in layer.modifiers)
+                            {
+                                if (modifier == null)
+                                {
+                                    continue;
+                                }
+
+                                modifierNames.Add(modifier.GetType().Name.Replace("Modifier", string.Empty));
+                            }
+
+                            if (modifierNames.Count > 0)
+                            {
+                                modifierSummary = string.Join(", ", modifierNames);
+                            }
+                        }
+
+                        GUILayout.Label($"Layer {i + 1}: {layer.pattern} | Stars: {layer.starCount} | Modifiers: {modifierSummary}");
+                    }
+                }
+                GUILayout.EndScrollView();
+
+                var estimate = entry.Estimate;
+                GUILayout.Label($"Peak Particles: {estimate.EstimatedPeakParticles:N0}");
+                GUILayout.Label($"Draw Calls: {estimate.EstimatedDrawCalls}");
+                GUILayout.Label($"Lifetime Sum: {estimate.TotalParticleLifetime:F1}");
+
+                if (estimate.EstimatedPeakParticles > warningParticleThreshold)
+                {
+                    GUILayout.Label($"⚠ High particle count (> {warningParticleThreshold:N0})");
+                }
+            }
+
+            GUILayout.EndVertical();
+            GUI.DragWindow(new Rect(0, 0, 10000f, 20f));
+        }
+
+        private void ApplySelectedRecipe()
+        {
+            if (examples.Count == 0)
+            {
+                return;
+            }
+
+            if (spawner == null)
+            {
+                spawner = FindObjectOfType<FireworkSpawner>();
+            }
+
+            var entry = examples[selectedIndex];
+            if (entry.RecipeInstance == null)
+            {
+                return;
+            }
+
+            entry.Estimate = spawner != null ? spawner.EstimateCost(entry.RecipeInstance) : RecipeCostUtility.Estimate(entry.RecipeInstance);
+            if (spawner != null)
+            {
+                spawner.SetActiveRecipe(entry.RecipeInstance);
+            }
+        }
+
+        private void ResetSelectedRecipe()
+        {
+            if (examples.Count == 0)
+            {
+                return;
+            }
+
+            var entry = examples[selectedIndex];
+            if (entry.RecipeInstance == null || string.IsNullOrEmpty(entry.DefaultJson))
+            {
+                return;
+            }
+
+            try
+            {
+                entry.RecipeInstance.ImportFromJson(entry.DefaultJson);
+                entry.Estimate = spawner != null ? spawner.EstimateCost(entry.RecipeInstance) : RecipeCostUtility.Estimate(entry.RecipeInstance);
+                if (spawner != null)
+                {
+                    spawner.SetActiveRecipe(entry.RecipeInstance);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"RecipeQuickUI: Failed to reset recipe '{entry.DisplayName}'. {ex.Message}");
+            }
+        }
+    }
+}

--- a/Assets/_Core/Runtime/UI/RecipeQuickUI.cs.meta
+++ b/Assets/_Core/Runtime/UI/RecipeQuickUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 81f9544c05624f288669ea51721eb7d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add a runtime RecipeQuickUI overlay for swapping example recipes, resetting data, and surfacing performance warnings
- provide a reusable RecipeCostUtility plus a spawner estimate method to surface peak particle and draw call projections
- extend RecipeJsonUtility with schema validation, safety logging, and ship six curated JSON recipes for quick testing

## Testing
- not run (Unity tests require the editor)

------
https://chatgpt.com/codex/tasks/task_e_68e03ba450c88328ae46c1f3bc57761c