### PR TITLE
Add RecipeQuickUI to modular demo scene

### DIFF
--- a/Assets/Scenes/Demo_Modular.unity
+++ b/Assets/Scenes/Demo_Modular.unity
@@ -308,8 +308,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a2d0dd621ab14943bdd39a22033b9931, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   launchers:
   - {fileID: 114100000}
   recipes:
@@ -321,6 +321,53 @@ MonoBehaviour:
   triggerKey: 32
   sizeScale: 1
   heightScale: 1
+--- !u!1 &10030
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 10031}
+  - component: {fileID: 10032}
+  m_Layer: 0
+  m_Name: RecipeQuickUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &10031
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 10030}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &10032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 10030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 81f9544c05624f288669ea51721eb7d8, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  spawner: {fileID: 10022}
+  examplesFolderRelative: RecipesJSON/Examples
+  warningParticleThreshold: 300000
+  autoApplyOnStart: 1
 --- !u!1001 &114100000
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- add a RecipeQuickUI host object to the Demo_Modular scene and wire it to the existing FireworkSpawner so the quick recipe controls are available

## Testing
- Not run (requires Unity Editor)


------
https://chatgpt.com/codex/tasks/task_e_68e041e078dc8328ae3db6aa21708690