### PR TITLE
Handle zero paper counts in workshop recipe

### DIFF
--- a/Assets/_Core/Runtime/Workshop/WorkshopRecipeBuilder.cs
+++ b/Assets/_Core/Runtime/Workshop/WorkshopRecipeBuilder.cs
@@ -26,7 +26,7 @@ namespace PyroLab.Fireworks
                 throw new ArgumentNullException(nameof(target));
             }
 
-            float paperCount = Mathf.Max(1, papers?.Count ?? 0);
+            float paperCount = papers?.Count ?? 0;
             float totalPaperLayers = 0f;
             float wrapSum = 0f;
             float thicknessSum = 0f;


### PR DESCRIPTION
## Summary
- stop clamping the paper count before averaging paper properties
- ensure averages fall back to the intended constants when no paper layers are provided

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e05a5ef0d0832889e577abe0011e0d