### PR TITLE
Prevent workshop modifiers from being saved

### DIFF
--- a/Assets/_Core/Runtime/Workshop/WorkshopRecipeBuilder.cs
+++ b/Assets/_Core/Runtime/Workshop/WorkshopRecipeBuilder.cs
@@ -91,6 +91,7 @@ namespace PyroLab.Fireworks
                 if (!addedGravityModifier)
                 {
                     var gravity = ScriptableObject.CreateInstance<GravityDragModifier>();
+                    gravity.hideFlags = HideFlags.DontSave;
                     gravity.gravityFactor = target.gravityFactor;
                     gravity.dragCurve = BuildDragCurve(averageThickness);
                     layer.modifiers.Add(gravity);
@@ -98,6 +99,7 @@ namespace PyroLab.Fireworks
                 }
 
                 var trail = ScriptableObject.CreateInstance<TrailModifier>();
+                trail.hideFlags = HideFlags.DontSave;
                 float starTrail = star != null ? star.trail : 0.2f;
                 trail.lengthScale = target.trailLengthScale + shellHardness * 2f + starTrail * 2f;
                 trail.velocityStretch = 0.6f;
@@ -106,6 +108,7 @@ namespace PyroLab.Fireworks
                 if (star != null && star.strobeFrequency > 0f)
                 {
                     var strobe = ScriptableObject.CreateInstance<StrobeModifier>();
+                    strobe.hideFlags = HideFlags.DontSave;
                     strobe.frequency = star.strobeFrequency;
                     strobe.duty = star.strobeDuty;
                     layer.modifiers.Add(strobe);
@@ -114,6 +117,7 @@ namespace PyroLab.Fireworks
                 if (star != null && star.twinkleAmount > 0f)
                 {
                     var twinkle = ScriptableObject.CreateInstance<TwinkleModifier>();
+                    twinkle.hideFlags = HideFlags.DontSave;
                     twinkle.twinkleProbability = star.twinkleAmount;
                     twinkle.intensityVariance = Mathf.Lerp(0.1f, 0.6f, star.twinkleAmount);
                     layer.modifiers.Add(twinkle);
@@ -197,6 +201,7 @@ namespace PyroLab.Fireworks
                 }
 
                 var cloneModifier = UnityEngine.Object.Instantiate(modifier);
+                cloneModifier.hideFlags = HideFlags.DontSave;
                 clone.modifiers.Add(cloneModifier);
             }
 


### PR DESCRIPTION
## Summary
- mark all workshop preview modifier ScriptableObjects with HideFlags.DontSave immediately after creation
- ensure cloned modifiers also inherit non-saving flags so runtime previews do not persist to assets

## Testing
- not run (Unity editor verification required)

------
https://chatgpt.com/codex/tasks/task_e_68e05f09775c8328a846bc9c946c8b7f